### PR TITLE
Added tox.ini

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .venv
+.tox

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 dist/
 build/
-src/sagemaker_xgboost_framework.egg-info/
+src/sagemaker_xgboost_container.egg-info/
 .venv
 *~
+.tox
+__pycache__
+.coverage*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt test-requirements.txt
+

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,8 @@ If you want to run unit tests, then use:
     # or you can use tox to run unit tests as well as flake8 and code coverage
 
     tox
+    tox -e py3-xgboost0.82,flake8
+    tox -e py3-xgboost0.72,py3-xgboostlatest
 
 
 Local Integration Tests

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     install_requires=read("requirements.txt"),
 
     extras_require={
-        'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8',
-                 'docker-compose', 'sagemaker>=1.3.0']
+        'test': read("test-requirements.txt")
     }
 )

--- a/src/sagemaker_xgboost_container/encoder.py
+++ b/src/sagemaker_xgboost_container/encoder.py
@@ -43,7 +43,7 @@ def csv_to_dmatrix(string_like, dtype=None):  # type: (str) -> xgb.DMatrix
     delimiter = ',' if sniff_delimiter.isalnum() else sniff_delimiter
     logging.info("Determined delimiter of CSV input is \'{}\'".format(delimiter))
 
-    np_payload = np.array(map(lambda x: _clean_csv_string(x, delimiter), string_like.split('\n'))).astype(dtype)
+    np_payload = np.array(list(map(lambda x: _clean_csv_string(x, delimiter), string_like.split('\n')))).astype(dtype)
     return xgb.DMatrix(np_payload)
 
 
@@ -58,7 +58,7 @@ def libsvm_to_dmatrix(string_like):  # type: (str) -> xgb.DMatrix
     try:
         with tempfile.NamedTemporaryFile(delete=False) as libsvm_file:
             temp_file_location = libsvm_file.name
-            libsvm_file.write(string_like)
+            libsvm_file.write(string_like.encode())
 
         dmatrix = xgb.DMatrix(temp_file_location)
     finally:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,11 @@
+tox
+flake8
+coverage
+pytest
+pytest-cov
+pytest-xdist
+mock
+Flask
+boto3>=1.4.8
+docker-compose
+sagemaker>=1.3.0

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -34,7 +34,7 @@ def test_libsvm_to_dmatrix(target):
     temp_libsvm_file_name = temp_libsvm_file.name
     assert os.path.exists(temp_libsvm_file_name)
 
-    with mock.patch('sagemaker_xgboost_framework.encoder.tempfile') as mock_tempfile:
+    with mock.patch('sagemaker_xgboost_container.encoder.tempfile') as mock_tempfile:
         mock_tempfile.NamedTemporaryFile.return_value = temp_libsvm_file
         actual = encoder.libsvm_to_dmatrix(target)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = {py3}-xgboost{0.82},flake8
+
+[flake8]
+max-line-length = 120
+
+[testenv]
+setenv = HADOOP_PREFIX = /not/real/path
+deps =
+    xgboost0.72: xgboost==0.72.1
+    xgboost0.82: xgboost==0.82
+    xgboostlatest: xgboost
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
+commands = pytest --cov=sagemaker_xgboost_container --cov-fail-under=20 test/unit # increase minimum bar over time (75%+)
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 setup.py src test


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

```
(.venv) sadoughi@u1d1fb0cf51fb5f:~/sagemaker-xgboost-framework$ tox -r
GLOB sdist-make: /home/ANT.AMAZON.COM/sadoughi/sagemaker-xgboost-framework/setup.py
py3-xgboost0.82 recreate: /home/ANT.AMAZON.COM/sadoughi/sagemaker-xgboost-framework/.tox/py3-xgboost0.82
py3-xgboost0.82 installdeps: xgboost==0.82, -r/home/ANT.AMAZON.COM/sadoughi/sagemaker-xgboost-framework/requirements.txt, -r/home/ANT.AMAZON.COM/sadoughi/sagemaker-xgboost-framework/test-requirements.txt
py3-xgboost0.82 inst: /home/ANT.AMAZON.COM/sadoughi/sagemaker-xgboost-framework/.tox/.tmp/package/1/sagemaker_xgboost_container-1.0.zip
py3-xgboost0.82 installed: apipkg==1.5,asn1crypto==0.24.0,atomicwrites==1.3.0,attrs==19.1.0,bcrypt==3.1.6,boto3==1.9.156,botocore==1.12.156,cached-property==1.5.1,certifi==2019.3.9,cffi==1.12.3,chardet==3.0.4,Click==7.0,coverage==4.5.3,cryptography==2.6.1,cycler==0.10.0,docker==3.7.2,docker-compose==1.24.0,docker-pycreds==0.4.0,dockerpty==0.4.1,docopt==0.6.2,docutils==0.14,entrypoints==0.3,execnet==1.6.0,filelock==3.0.12,flake8==3.7.7,Flask==1.0.3,gevent==1.4.0,greenlet==0.4.15,gunicorn==19.9.0,idna==2.7,importlib-metadata==0.15,inotify-simple==1.1.8,itsdangerous==1.1.0,Jinja2==2.10.1,jmespath==0.9.4,joblib==0.13.2,jsonschema==2.6.0,kiwisolver==1.1.0,MarkupSafe==1.1.1,matplotlib==3.1.0,mccabe==0.6.1,mock==3.0.5,more-itertools==7.0.0,numpy==1.16.3,pandas==0.24.2,paramiko==2.4.2,pluggy==0.12.0,protobuf==3.7.1,protobuf3-to-dict==0.1.5,psutil==5.6.2,py==1.8.0,pyasn1==0.4.5,pycodestyle==2.5.0,pycparser==2.19,pyflakes==2.1.1,PyNaCl==1.3.0,pyparsing==2.4.0,pytest==4.5.0,pytest-cov==2.7.1,pytest-forked==1.0.2,pytest-xdist==1.28.0,python-dateutil==2.8.0,pytz==2019.1,PyYAML==3.13,requests==2.20.1,retrying==1.3.3,s3transfer==0.2.0,sagemaker==1.23.0,sagemaker-containers==2.4.10,sagemaker-xgboost-container==1.0,scikit-learn==0.21.2,scipy==1.3.0,six==1.12.0,texttable==0.9.1,toml==0.10.0,tox==3.12.1,typing==3.6.6,urllib3==1.24.3,virtualenv==16.6.0,wcwidth==0.1.7,websocket-client==0.56.0,Werkzeug==0.15.4,xgboost==0.82,zipp==0.5.1
py3-xgboost0.82 run-test-pre: PYTHONHASHSEED='1600357371'
py3-xgboost0.82 run-test: commands[0] | pytest --cov=sagemaker_xgboost_container --cov-fail-under=20 test/unit
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.6.7, pytest-4.5.0, py-1.8.0, pluggy-0.12.0
cachedir: .tox/py3-xgboost0.82/.pytest_cache
rootdir: /home/ANT.AMAZON.COM/sadoughi/sagemaker-xgboost-framework
plugins: cov-2.7.1, forked-1.0.2, xdist-1.28.0
collected 18 items                                                                                                                                                                                 

test/unit/test_encoder.py ........                                                                                                                                                           [ 44%]
test/unit/test_serving.py .........                                                                                                                                                          [ 94%]
test/unit/test_training.py .                                                                                                                                                                 [100%]

----------- coverage: platform linux, python 3.6.7-final-0 -----------
Name                                                                                                                     Stmts   Miss  Cover
--------------------------------------------------------------------------------------------------------------------------------------------
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/__init__.py                                     0      0   100%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/bootstrap.py                                   69     57    17%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/constants/__init__.py                           0      0   100%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/constants/xgb_constants.py                     14      0   100%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/constants/xgb_content_types.py                  2      0   100%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/default_entry_point.py                         42     26    38%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/encoder.py                                     35      0   100%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/exceptions.py                                  94     61    35%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/metrics/__init__.py                             0      0   100%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/metrics/performance_metric_definitions.py      51     28    45%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/metrics/performance_metrics.py                 99     79    20%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/metrics/utils.py                               38     22    42%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/serving.py                                     34     12    65%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/train_helper.py                               540    491     9%
.tox/py3-xgboost0.82/lib/python3.6/site-packages/sagemaker_xgboost_container/training.py                                    13      3    77%
--------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                                     1031    779    24%

Required test coverage of 20% reached. Total coverage: 24.44%

==================================================================================== 18 passed in 0.55 seconds =====================================================================================
flake8 recreate: /home/ANT.AMAZON.COM/sadoughi/sagemaker-xgboost-framework/.tox/flake8
flake8 installdeps: flake8
flake8 inst: /home/ANT.AMAZON.COM/sadoughi/sagemaker-xgboost-framework/.tox/.tmp/package/1/sagemaker_xgboost_container-1.0.zip
flake8 installed: asn1crypto==0.24.0,bcrypt==3.1.6,boto3==1.9.156,botocore==1.12.156,cffi==1.12.3,Click==7.0,cryptography==2.6.1,cycler==0.10.0,docutils==0.14,entrypoints==0.3,flake8==3.7.7,Flask==1.0.3,gevent==1.4.0,greenlet==0.4.15,gunicorn==19.9.0,inotify-simple==1.1.8,itsdangerous==1.1.0,Jinja2==2.10.1,jmespath==0.9.4,joblib==0.13.2,kiwisolver==1.1.0,MarkupSafe==1.1.1,matplotlib==3.1.0,mccabe==0.6.1,numpy==1.16.3,pandas==0.24.2,paramiko==2.4.2,psutil==5.6.2,pyasn1==0.4.5,pycodestyle==2.5.0,pycparser==2.19,pyflakes==2.1.1,PyNaCl==1.3.0,pyparsing==2.4.0,python-dateutil==2.8.0,pytz==2019.1,retrying==1.3.3,s3transfer==0.2.0,sagemaker-containers==2.4.10,sagemaker-xgboost-container==1.0,scikit-learn==0.21.2,scipy==1.3.0,six==1.12.0,typing==3.6.6,urllib3==1.25.3,Werkzeug==0.15.4
flake8 run-test-pre: PYTHONHASHSEED='1600357371'
flake8 run-test: commands[0] | flake8 setup.py src test
_____________________________________________________________________________________________ summary ______________________________________________________________________________________________
  py3-xgboost0.82: commands succeeded
  flake8: commands succeeded
  congratulations :)
```