### PR TITLE
Replaced objective reg:linear with reg:squarederror to match xgboost-…

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -187,7 +187,7 @@ def initialize(metrics):
         hpv.CategoricalHyperparameter(name="objective",
                                       range=["binary:logistic", "binary:logitraw", "binary:hinge",
                                              "count:poisson", "multi:softmax", "multi:softprob",
-                                             "rank:pairwise", "rank:ndcg", "rank:map", "reg:linear",
+                                             "rank:pairwise", "rank:ndcg", "rank:map", "reg:squarederror",
                                              "reg:logistic", "reg:gamma", "reg:tweedie", "survival:cox", ],
                                       dependencies=objective_validator,
                                       required=False),


### PR DESCRIPTION
…0.90.1 documentation.

*Issue #, if available:*

*Description of changes:*
Replace reg:linear with reg:squarederror to match public documentation: https://github.com/dmlc/xgboost/blob/master/doc/parameter.rst

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
