### PR TITLE
Fix hyperparameter validation for objective when eval_metric is auc.

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -94,8 +94,8 @@ def initialize(metrics):
     @hpv.dependencies_validator(["objective"])
     def eval_metric_dep_validator(value, dependencies):
         if "auc" in value:
-            if any(metric_type in dependencies["objective"] for metric_type in [
-                    'count:', 'multi:', 'reg:', 'survival:']):
+            if not any(metric_type in dependencies["objective"] for metric_type in [
+                    'binary:', 'rank:']):
                 raise exc.UserError("Metric 'auc' can only be applied for classification and ranking problems.")
 
     hyperparameters = hpv.Hyperparameters(

--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -94,10 +94,9 @@ def initialize(metrics):
     @hpv.dependencies_validator(["objective"])
     def eval_metric_dep_validator(value, dependencies):
         if "auc" in value:
-            if (dependencies["objective"] not in
-                ["binary:logistic", "binary:logitraw", "multi:softmax", "multi:softprob",
-                 "reg:logistic", "rank:pairwise", "binary:hinge"]):
-                raise exc.UserError("Metric 'auc' can only be applied for classification and ranking problem.")
+            if any(metric_type in dependencies["objective"] for metric_type in [
+                    'count:', 'multi:', 'reg:', 'survival:']):
+                raise exc.UserError("Metric 'auc' can only be applied for classification and ranking problems.")
 
     hyperparameters = hpv.Hyperparameters(
         hpv.IntegerHyperparameter(name="num_round", required=True,
@@ -187,8 +186,8 @@ def initialize(metrics):
         hpv.CategoricalHyperparameter(name="objective",
                                       range=["binary:logistic", "binary:logitraw", "binary:hinge",
                                              "count:poisson", "multi:softmax", "multi:softprob",
-                                             "rank:pairwise", "rank:ndcg", "rank:map", "reg:linear", 
-                                             "reg:squarederror", "reg:logistic", "reg:gamma", 
+                                             "rank:pairwise", "rank:ndcg", "rank:map", "reg:linear",
+                                             "reg:squarederror", "reg:logistic", "reg:gamma",
                                              "reg:tweedie", "survival:cox"],
                                       dependencies=objective_validator,
                                       required=False),

--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -94,7 +94,7 @@ def initialize(metrics):
     @hpv.dependencies_validator(["objective"])
     def eval_metric_dep_validator(value, dependencies):
         if "auc" in value:
-            if not any(metric_type in dependencies["objective"] for metric_type in [
+            if not any(dependencies["objective"].startswith(metric_type) for metric_type in [
                     'binary:', 'rank:']):
                 raise exc.UserError("Metric 'auc' can only be applied for classification and ranking problems.")
 

--- a/test/unit/algorithm_mode/test_hyperparameter_validation.py
+++ b/test/unit/algorithm_mode/test_hyperparameter_validation.py
@@ -29,11 +29,13 @@ class TestHyperparameterValidation(unittest.TestCase):
             'eval_metric': 'auc'}
 
         auc_invalid_objectives = [
+            'count:poisson',
             'reg:gamma',
             'reg:logistic',
             'reg:squarederror',
             'reg:tweedie',
-            'count:poisson',
+            'multi:softmax',
+            'multi:softprob',
             'survival:cox']
 
         for invalid_objective in auc_invalid_objectives:

--- a/test/unit/algorithm_mode/test_hyperparameter_validation.py
+++ b/test/unit/algorithm_mode/test_hyperparameter_validation.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+import unittest
+
+from sagemaker_algorithm_toolkit import exceptions as exc
+
+from sagemaker_xgboost_container.algorithm_mode import hyperparameter_validation as hpv
+from sagemaker_xgboost_container.algorithm_mode import metrics as metrics_mod
+
+metrics = metrics_mod.initialize()
+hyperparameters = hpv.initialize(metrics)
+
+
+class TestHyperparameterValidation(unittest.TestCase):
+
+    def test_auc_invalid_objective(self):
+        test_hp = {
+            'eval_metric': 'auc'}
+
+        auc_invalid_objectives = [
+            'reg:gamma',
+            'reg:logistic',
+            'reg:squarederror',
+            'reg:tweedie',
+            'count:poisson',
+            'survival:cox']
+
+        for invalid_objective in auc_invalid_objectives:
+            test_hp['objective'] = invalid_objective
+
+            with self.assertRaises(exc.UserError):
+                hyperparameters.validate(test_hp)


### PR DESCRIPTION
*Description of changes:*

Fixed hyperparameter validation to use black list of objective functions when eval_metric includes 'auc'.

Note: Need to double check for multiclass objectives

*Test*
python3 -m tox

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
