### PR TITLE
Fix README documentation. Remove unnecessary LIBSVM check in CSV inpu…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,8 @@ Base Images
 The "base" Dockerfile encompass the installation of the framework and all of the dependencies
 needed.
 
-Tagging scheme is based on <XGBoost-version>-cpu-py3. (e.g. 0.20.0-cpu-py3)
+Tagging scheme is based on <SageMaker-XGBoost-version>-cpu-py3 (e.g. 0.90-1-cpu-py3), where
+ <SageMaker-XGBoost-version> is comprised of <XGBoost-version>-<SageMaker-version>.
 
 All "final" Dockerfiles build images using base images that use the tagging scheme
 above.
@@ -68,10 +69,10 @@ If you want to build your base docker image, then use:
 
 ::
 
-    # All build instructions assume you're building from the root directory of the sagemaker-scikit-learn-container.
+    # All build instructions assume you're building from the root directory of the sagemaker-xgboost-container.
 
     # CPU
-    docker build -t xgboost-container-base:<xgboost-version>-cpu-py3 -f docker/<xgboost-version>/base/Dockerfile.cpu .
+    docker build -t xgboost-container-base:<SageMaker-XGBoost-version>-cpu-py3 -f docker/<SageMaker-XGBoost-version>/base/Dockerfile.cpu .
 
 ::
 
@@ -89,7 +90,7 @@ The "final" Dockerfiles encompass the installation of the SageMaker specific sup
 All "final" Dockerfiles use base images for building.
 
 These "base" images are specified with the naming convention of
-xgboost-container-base:<xgboost-version>-cpu-py3.
+xgboost-container-base:<SageMaker-XGBoost-version>-cpu-py3.
 
 Before building "final" images:
 
@@ -98,7 +99,7 @@ Dockerfile.
 
 ::
 
-    # Create the SageMaker Scikit-learn Container Python package.
+    # Create the SageMaker XGBoost Container Python package.
     cd sagemaker-xgboost-container
     python setup.py bdist_wheel --universal
 
@@ -148,7 +149,7 @@ If you want to run unit tests, then use:
     # or you can use tox to run unit tests as well as flake8 and code coverage
 
     tox
-    tox -e py3-xgboost0.82,flake8
+    tox -e py3-xgboost0.90,flake8
     tox -e py3-xgboost0.72,py3-xgboostlatest
 
 

--- a/src/sagemaker_xgboost_container/data_utils.py
+++ b/src/sagemaker_xgboost_container/data_utils.py
@@ -162,11 +162,6 @@ def _validate_csv_format(file_path):
         line_to_validate = read_file.readline()
         _get_csv_delimiter(line_to_validate)
 
-        if _get_num_valid_libsvm_features(line_to_validate) > 0:
-            # Throw error if this line can be parsed as LIBSVM formatted line.
-            raise exc.UserError(_get_invalid_csv_error_msg(
-                line_snippet=line_to_validate, file_name=file_path.split('/')[-1]))
-
 
 def _validate_libsvm_format(file_path):
     """Validate that data file is LIBSVM format.


### PR DESCRIPTION
…t validation.

## Description of changes:

* Fix README
* Remove unnecessary LIBSVM validation in CSV validation.
  * Originally, the validation was added in case customer data was formatted with a unorthodox delim such as ' 2:', causing the data to look like LIBSVM: ```1 2:1 2:3 2:1 -> 1,2,3,1```. However, retrospectively this should not have been added; if the customer wants to use CSV format with such delim, that should be allowed.

## Test
Ran all unit tests successfully using ```python3 -m tox```.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
