### PR TITLE
Added support for label_size=1 as an optional parameter for csv.

### DIFF
--- a/test/unit/test_data_utils.py
+++ b/test/unit/test_data_utils.py
@@ -31,9 +31,21 @@ class TestTrainUtils(unittest.TestCase):
 
         self.assertEqual('csv', data_utils.get_content_type('csv'))
         self.assertEqual('csv', data_utils.get_content_type('text/csv'))
+        self.assertEqual('csv', data_utils.get_content_type('text/csv; label_size=1'))
+        self.assertEqual('csv', data_utils.get_content_type('text/csv;label_size = 1'))
+        self.assertEqual('csv', data_utils.get_content_type('text/csv; charset=utf-8'))
+        self.assertEqual('csv', data_utils.get_content_type('text/csv; label_size=1; charset=utf-8'))
 
         with self.assertRaises(exc.UserError):
             data_utils.get_content_type('incorrect_format')
+        with self.assertRaises(exc.UserError):
+            data_utils.get_content_type('text/csv; label_size=5')
+        with self.assertRaises(exc.UserError):
+            data_utils.get_content_type('text/csv; label_size=1=1')
+        with self.assertRaises(exc.UserError):
+            data_utils.get_content_type('text/csv; label_size=1; label_size=2')
+        with self.assertRaises(exc.UserError):
+            data_utils.get_content_type('label_size=1; text/csv')
 
     def test_validate_csv_files(self):
         csv_file_paths = ['train.csv', 'train.csv.weights', 'csv_files']


### PR DESCRIPTION
*Issue #, if available:*
https://issues.amazon.com/issues/AWSMLC-77

*Description of changes:*
Added additional handling in data_utils.py to check for 'text/csv' content type with the ``label_size`` optional parameter. If the ``label_size`` is present and is set to 1, the content type is accepted, otherwise a ``UserError`` is raised.

*Testing:*
Added two assert statements in the ``test_get_content_type`` unit test. Tests were run with tox and passed successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
