### PR TITLE
Add default content type support for algorithm toolkit channel valdat…

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/channel_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/channel_validation.py
@@ -38,4 +38,7 @@ def initialize():
     code_channel = cv.Channel(name="code", required=False)
     code_channel.add("text/python", cv.Channel.FILE_MODE, cv.Channel.REPLICATED)
 
-    return cv.Channels(train_channel, validation_channel, code_channel)
+    data_channels = cv.Channels(train_channel, validation_channel, code_channel)
+    data_channels.set_default_content_type("text/libsvm")
+
+    return data_channels

--- a/test/unit/algorithm_mode/test_channel_validation.py
+++ b/test/unit/algorithm_mode/test_channel_validation.py
@@ -1,0 +1,36 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+import unittest
+
+from sagemaker_algorithm_toolkit import channel_validation as cv
+from sagemaker_xgboost_container.algorithm_mode import channel_validation as acv
+
+REQUIRED_CHANNEL = "required"
+NOT_REQUIRED_CHANNEL = "not_required"
+
+
+class TestChannelValidation(unittest.TestCase):
+
+    def setUp(self):
+        self.channels = acv.initialize()
+
+    def test_default_content_type(self):
+        test_user_channels = {
+            "train": {
+                cv.TRAINING_INPUT_MODE: "File",
+                cv.S3_DIST_TYPE: "FullyReplicated"
+            }
+        }
+        self.channels.validate(test_user_channels)
+        self.assertEquals(test_user_channels["train"][cv.CONTENT_TYPE], "text/libsvm")

--- a/test/unit/algorithm_toolkit/test_channel_validation.py
+++ b/test/unit/algorithm_toolkit/test_channel_validation.py
@@ -21,24 +21,36 @@ class TestChannelValidation(unittest.TestCase):
         channel = cv.Channel(name="train", required=True)
         channel.add("text/csv", cv.Channel.FILE_MODE, cv.Channel.REPLICATED)
         channels = cv.Channels(channel)
-        channels.validate({"train": {"ContentType": "text/csv", "TrainingInputMode": "File",
-                                     "S3DistributionType": "FullyReplicated", "RecordWrapperType": "None"}})
+        channels.validate({"train": {cv.CONTENT_TYPE: "text/csv", cv.TRAINING_INPUT_MODE: "File",
+                                     cv.S3_DIST_TYPE: "FullyReplicated", "RecordWrapperType": "None"}})
+
+    def test_default_content_type(self):
+        channel = cv.Channel(name="train", required=True)
+        channel.add("text/csv", cv.Channel.FILE_MODE, cv.Channel.REPLICATED)
+        channels = cv.Channels(channel)
+        channels.set_default_content_type("text/csv")
+        test_user_channels = {"train": {
+            cv.TRAINING_INPUT_MODE: "File",
+            cv.S3_DIST_TYPE: "FullyReplicated",
+            "RecordWrapperType": "None"}}
+        channels.validate(test_user_channels)
+        self.assertEqual(test_user_channels["train"][cv.CONTENT_TYPE], "text/csv")
 
     def test_simple_not_supported(self):
         channel = cv.Channel(name="train", required=True)
         channel.add("text/csv", cv.Channel.FILE_MODE, cv.Channel.REPLICATED)
         channels = cv.Channels(channel)
         with self.assertRaises(exc.UserError):
-            channels.validate({"train": {"ContentType": "text/csv", "TrainingInputMode": "Pipe",
-                                         "S3DistributionType": "FullyReplicated", "RecordWrapperType": "None"}})
+            channels.validate({"train": {cv.CONTENT_TYPE: "text/csv", cv.TRAINING_INPUT_MODE: "Pipe",
+                                         cv.S3_DIST_TYPE: "FullyReplicated", "RecordWrapperType": "None"}})
 
     def test_simple_extra(self):
         channel = cv.Channel(name="train", required=True)
         channel.add("text/csv", cv.Channel.FILE_MODE, cv.Channel.REPLICATED)
         channels = cv.Channels(channel)
         with self.assertRaises(exc.UserError):
-            channels.validate({"train": {"ContentType": "text/csv", "TrainingInputMode": "File",
-                                         "S3DistributionType": "FullyReplicated", "RecordWrapperType": "None"},
+            channels.validate({"train": {cv.CONTENT_TYPE: "text/csv", cv.TRAINING_INPUT_MODE: "File",
+                                         cv.S3_DIST_TYPE: "FullyReplicated", "RecordWrapperType": "None"},
                                "extra": {}})
 
     def test_simple_required(self):


### PR DESCRIPTION
…ion.

*Description of changes:*

Add default content type support for channel validation.
Add "text/libsvm" as default content type for XGBoost.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
