### PR TITLE
Fix incorrect DMatrix argument in data_utils.py:472.

### DIFF
--- a/src/sagemaker_xgboost_container/data_utils.py
+++ b/src/sagemaker_xgboost_container/data_utils.py
@@ -389,7 +389,7 @@ def _get_parquet_dmatrix_file_mode(files_path):
 
         dmatrix = xgb.DMatrix(data[:, 1:], label=data[:, 0])
         del data
-        
+
         return dmatrix
 
     except Exception as e:
@@ -469,7 +469,7 @@ def get_recordio_protobuf_dmatrix(path, is_pipe=False):
             data = np.vstack(examples)
             del examples
 
-            dmatrix = xgb.DMatrix(data[:, 1:], labels=data[:, 0])
+            dmatrix = xgb.DMatrix(data[:, 1:], label=data[:, 0])
             return dmatrix
         else:
             return None


### PR DESCRIPTION
*Description of changes:*
Replace incorrect argument `labels` with `label` when constructing DMatrix from recordio-protobuf data.

Change tested by running tox, failure before this change and all unit tests passing after.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
