### PR TITLE
Use Python 3.7 installed with conda

### DIFF
--- a/docker/0.90-2/base/Dockerfile.cpu
+++ b/docker/0.90-2/base/Dockerfile.cpu
@@ -24,12 +24,6 @@ RUN conda update -y conda && \
     conda install -c conda-forge pyarrow=0.14.1 && \
     conda install -c mlio -c conda-forge mlio-py=0.1
 
-# Install pip
-RUN cd /tmp && \
-    curl -O https://bootstrap.pypa.io/get-pip.py && \
-    python3 get-pip.py && \
-    rm get-pip.py
-
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/docker/0.90-2/base/Dockerfile.cpu
+++ b/docker/0.90-2/base/Dockerfile.cpu
@@ -2,29 +2,38 @@ FROM ubuntu:16.04
 
 # Install python and other runtime dependencies
 RUN apt-get update && \
-    apt-get -y install build-essential libatlas-dev git wget curl nginx jq && \
-    apt-get -y install python3-dev python3-setuptools && \
+    apt-get -y install \
+        build-essential \
+        libatlas-dev \
+        git \
+        wget \
+        curl \
+        nginx \
+        jq && \
     apt-get -y install openjdk-8-jdk-headless
+
+# Install mlio
+RUN echo 'installing miniconda' && \
+    curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3 && \
+    rm Miniconda3-latest-Linux-x86_64.sh
+
+ENV PATH=/miniconda3/bin:${PATH}
+
+RUN conda update -y conda && \
+    conda install -c conda-forge pyarrow=0.14.1 && \
+    conda install -c mlio -c conda-forge mlio-py=0.1
 
 # Install pip
 RUN cd /tmp && \
-     curl -O https://bootstrap.pypa.io/get-pip.py && \
-     python3 get-pip.py && \
-     rm get-pip.py
-
-# Install mlio
-RUN echo 'installing miniconda'
-RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-RUN bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3
-RUN rm Miniconda3-latest-Linux-x86_64.sh
-ENV PATH=/miniconda3/bin:${PATH}
-RUN conda update -y conda
-RUN conda install -c conda-forge pyarrow=0.14.1
-RUN conda install -c mlio -c conda-forge mlio-py=0.1
+    curl -O https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    rm get-pip.py
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING='utf-8'
 
 # Install latest version of XGBoost

--- a/docker/0.90-2/final/Dockerfile.cpu
+++ b/docker/0.90-2/final/Dockerfile.cpu
@@ -19,7 +19,7 @@ RUN pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
 ##############
 # TODO: remove after making contributions back to xgboost for tracker.py
 COPY src/sagemaker_xgboost_container/dmlc_patch/tracker.py \
-   /usr/local/lib/python3.5/dist-packages/xgboost/dmlc-core/tracker/dmlc_tracker/tracker.py
+   /miniconda3/lib/python3.7/site-packages/xgboost/dmlc-core/tracker/dmlc_tracker/tracker.py
 
 #######
 # MMS #
@@ -62,7 +62,7 @@ ENV SAGEMAKER_TRAINING_MODULE sagemaker_xgboost_container.training:main
 ENV SAGEMAKER_SERVING_MODULE sagemaker_xgboost_container.serving:main
 
 # Include DMLC python code in PYTHONPATH to use RabitTracker
-ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.5/dist-packages/xgboost/dmlc-core/tracker
+ENV PYTHONPATH=$PYTHONPATH:/miniconda3/lib/python3.7/site-packages/xgboost/dmlc-core/tracker
 
 EXPOSE 8080
 ENV TEMP=/home/model-server/tmp


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**R2**

Removed unnecessary pip download and installation. pip is available in Conda.

*Tests*
```
pytest test/integration
```
Internal container tests and integration tests all passed (except HPO).

**R1**

Since we now use conda to install ml-io, this PR proposes moving to Python 3.7. Previously `apt-get install python3` installed ubuntu 16's default python version 3.5. By removing `apt-get install python3`, the conda-installed Python is used.

*Tests:*
```
pytest test/integration
```
Internal functional tests and integration tests all passed (except HPO).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
