### PR TITLE
Add codebuild spec for running tests

### DIFF
--- a/ci/buildspec-tests.yml
+++ b/ci/buildspec-tests.yml
@@ -1,0 +1,29 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+    - echo Installing dependencies...
+    - curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    - bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3
+    - export PATH=/miniconda3/bin:${PATH}
+    - conda update -y conda
+    - conda install -y 'requests<2.21'  # sagemaker-python-sdk requires requests<2.21
+    - pip install -e .[test]
+  build:
+    commands:
+    - echo Build started on `date`
+    - echo Building the Docker image...
+    - docker build -t xgboost-container-base:0.90-2-cpu-py3 -f docker/0.90-2/base/Dockerfile.cpu .
+    - python setup.py bdist_wheel --universal
+    - docker build -t preprod-xgboost-container:0.90-2-cpu-py3 -f docker/0.90-2/final/Dockerfile.cpu .
+    - echo Running unit tests
+    - tox
+    - echo Running local integration tests
+    - pytest test/integration/local --docker-base-name preprod-xgboost-container --tag 0.90-2-cpu-py3 --py-version 3 --framework-version 0.90-2
+  post_build:
+    commands:
+    - echo Build completed on `date`

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-Flask
+flask==1.1.1  # sagemaker-containers requires flask==1.1.1
 PyYAML<4.3
 boto3>=1.4.8
 coverage


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds a `buildspec-tests.yml` for running unit tests (via `tox`) and integration tests (`pytest test/integration`) in codebuild. This new yaml file is intended to be used for running tests when new PRs are opened. The existing codebulid project uses `ci/buildspec.yml` to build a new docker image and push it to ECR. Thus, the proposed workflow is:

PR opened -> `buildspec_tests.yml` runs tests -> PR is merged -> `buildspec.yml` builds docker image and pushes to ECR.

Additional steps have to be performed on AWS to set up CodeBuild. Proposed steps are as follows:
- The person needs admin privileges for account 515193369038.
- Create a second build project that monitors this github repository.
- Configure the build to be triggered from the following event types: `PULL_REQUEST_CREATED`, `PULL_REQUEST_UPDATED`, and `PULL_REQUEST_REOPEND`. (Should we also add `PULL_REQUEST_MERGED`?)
- The role attached to the build project needs S3 access permissions.
- Configure it to use `ci/buildspec-test.yml`.
- `buildspec_tests.yml` was tested with the image `aws/codebuild/amazonlinux2-x86_64-standard:1.0`.
- If necessary, change the existing build project to be triggered by push events to `master`.
- Additional steps might need to be performed by owners of this repository to have the new webhook be triggered only for pull requests (not push events).

**Tests**

Tested in my fork: https://github.com/edwardjkim/sagemaker-xgboost-container/pull/4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
