### PR TITLE
Dynamically set heap and direct memory limits.

### DIFF
--- a/docker/0.90-2/final/Dockerfile.cpu
+++ b/docker/0.90-2/final/Dockerfile.cpu
@@ -30,7 +30,7 @@ RUN mkdir -p /home/model-server/tmp
 RUN chown -R model-server /home/model-server
 
 # Copy MMS configs
-COPY docker/$SAGEMAKER_XGBOOST_VERSION/resources/mms/config.properties /home/model-server
+COPY docker/$SAGEMAKER_XGBOOST_VERSION/resources/mms/config.properties.tmp /home/model-server
 ENV XGBOOST_MMS_CONFIG=/home/model-server/config.properties
 
 # Copy execution parameters endpoint plugin for MMS

--- a/docker/0.90-2/resources/mms/config.properties.tmp
+++ b/docker/0.90-2/resources/mms/config.properties.tmp
@@ -7,3 +7,4 @@ default_workers_per_model=$$SAGEMAKER_NUM_MODEL_WORKERS$$
 max_request_size=$$SAGEMAKER_MAX_REQUEST_SIZE$$
 decode_input_request=false
 default_service_handler=$$SAGEMAKER_MMS_DEFAULT_HANDLER$$
+job_queue_size=$$SAGEMAKER_MODEL_JOB_QUEUE_SIZE$$

--- a/docker/0.90-2/resources/mms/config.properties.tmp
+++ b/docker/0.90-2/resources/mms/config.properties.tmp
@@ -1,4 +1,3 @@
-vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
 model_store=$$SAGEMAKER_MMS_MODEL_STORE$$
 load_models=$$SAGEMAKER_MMS_LOAD_MODELS$$
 plugins_path=/tmp/plugins


### PR DESCRIPTION
*Description of changes:*
The `MaxDirectMemorySize` parameter limits the amount of direct memory that the JVM can use. This has a direct effect of limiting the size of inference requests we can make, causing `OutOfDirectMemoryError`s as soon as the 10MB limit is reached. This was temporarily raised during testing to 1GB. 

After raising the direct memory limit, the `Xmx` parameter, which limits the max heap size, began causing `OutOfMemoryError`s when testing batch transform jobs. After raising that limit as well, the errors were resolved.

The `Xmx` and `MaxDirectMemorySize` vmargs are now set based on the number of workers * the max payload size * a buffering factor of 1.2  + a base amount of 128mb, which is theoretically sufficient for the server when under full load (all workers occupied). Environment variables are not parsed for vmargs (MMS has not implemented this yet), so the current workaround is to write the values to the config.properties file before model startup.

Change were tested by running container tests and batch transform jobs with small (<5MB) and larger payloads (up to 20MB).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
