### PR TITLE
Remove additional parameters from content_type

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/handler_service.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/handler_service.py
@@ -24,6 +24,8 @@ from sagemaker_xgboost_container.algorithm_mode.mms_transformer import Transform
 from sagemaker_xgboost_container import encoder as xgb_encoder
 from sagemaker_xgboost_container.algorithm_mode.inference_errors import NoContentInferenceError, \
     UnsupportedMediaTypeInferenceError, ModelLoadInferenceError, BadRequestInferenceError
+from sagemaker_xgboost_container.data_utils import get_content_type
+from sagemaker_xgboost_container.data_utils import CSV, LIBSVM, PARQUET, RECORDIO_PROTOBUF
 
 
 SAGEMAKER_BATCH = os.getenv("SAGEMAKER_BATCH")
@@ -55,23 +57,21 @@ def _get_sparse_matrix_from_libsvm(payload):
     return csr_matrix((data, (row, col)))
 
 
-def predict(booster, model_format, dtest, content_type):
+def predict(booster, model_format, dtest, input_content_type):
     if model_format == 'pkl_format':
         x = len(booster.feature_names)
         y = len(dtest.feature_names)
 
-        if content_type == 'text/x-libsvm' or content_type == 'text/libsvm':
+        content_type = get_content_type(input_content_type)
+        if content_type == LIBSVM:
             if y > x + 1:
                 raise ValueError('Feature size of libsvm inference data {} is larger than '
                                  'feature size of trained model {}.'.format(y, x))
-        elif content_type == 'application/x-recordio-protobuf':
+        elif content_type in [CSV, RECORDIO_PROTOBUF]:
             if not ((x == y) or (x == y + 1)):
-                raise ValueError('Feature size of recordio-protobuf inference data {} is not consistent '
-                                 'with feature size of trained model {}.'.format(y, x))
-        elif content_type == 'text/csv':
-            if not ((x == y) or (x == y + 1)):
-                raise ValueError('Feature size of csv inference data {} is not consistent '
-                                 'with feature size of trained model {}'.format(y, x))
+                raise ValueError('Feature size of {} inference data {} is not consistent '
+                                 'with feature size of trained model {}.'.
+                                 format(content_type, y, x))
         else:
             raise ValueError('Content type {} is not supported'.format(content_type))
     return booster.predict(dtest,
@@ -114,7 +114,7 @@ class HandlerService(DefaultHandlerService):
             booster.set_param('nthread', 1)
             return booster, format
 
-        def default_input_fn(self, input_data, content_type):
+        def default_input_fn(self, input_data, input_content_type):
             """Take request data and de-serializes the data into an object for prediction.
                 When an InvokeEndpoint operation is made against an Endpoint running SageMaker model server,
                 the model server receives two pieces of information:
@@ -123,45 +123,45 @@ class HandlerService(DefaultHandlerService):
                 The input_fn is responsible to take the request data and pre-process it before prediction.
             Args:
                 input_data (obj): the request data.
-                content_type (str): the request Content-Type. XGBoost accepts CSV, LIBSVM, and RECORDIO-PROTOBUF.
+                input_content_type (str): the request Content-Type. XGBoost accepts CSV, LIBSVM, and RECORDIO-PROTOBUF.
             Returns:
                 (obj): data ready for prediction. For XGBoost, this defaults to DMatrix.
             """
             if len(input_data) == 0:
                 raise NoContentInferenceError()
-
-            if content_type == "text/csv":
+            content_type = get_content_type(input_content_type)
+            if content_type == CSV:
                 try:
                     input_data = input_data.decode('utf-8')
                     payload = input_data.strip()
                     dtest = xgb_encoder.csv_to_dmatrix(payload, dtype=np.float)
                 except Exception as e:
-                    raise UnsupportedMediaTypeInferenceError("Loading csv data failed with "
-                                                             "Exception, please ensure data "
-                                                             "is in csv format: {} {}".format(type(e),
-                                                                                              e))
-            elif content_type == "text/x-libsvm" or content_type == 'text/libsvm':
+                    raise UnsupportedMediaTypeInferenceError(
+                        "Loading csv data failed with "
+                        "Exception, please ensure data "
+                        "is in csv format: {} {}".format(type(e), e))
+            elif content_type == LIBSVM:
                 try:
-                    # if not isinstance(input_data, str):
                     input_data = input_data.decode('utf-8')
                     payload = input_data.strip()
                     dtest = xgb.DMatrix(_get_sparse_matrix_from_libsvm(payload))
                 except Exception as e:
-                    raise UnsupportedMediaTypeInferenceError("Loading libsvm data failed with "
-                                                             "Exception, please ensure data "
-                                                             "is in libsvm format: {} {}".format(type(e),
-                                                                                                 e))
-            elif content_type == "application/x-recordio-protobuf":
+                    raise UnsupportedMediaTypeInferenceError(
+                        "Loading libsvm data failed with "
+                        "Exception, please ensure data "
+                        "is in libsvm format: {} {}".format(type(e), e))
+            elif content_type == RECORDIO_PROTOBUF:
                 try:
                     payload = input_data
                     dtest = xgb_encoder.recordio_protobuf_to_dmatrix(payload)
                 except Exception as e:
-                    raise UnsupportedMediaTypeInferenceError("Loading recordio-protobuf data failed with "
-                                                             "Exception, please ensure data is in "
-                                                             "recordio-protobuf format: {} {}".format(type(e),
-                                                                                                      e))
+                    raise UnsupportedMediaTypeInferenceError(
+                        "Loading recordio-protobuf data failed with "
+                        "Exception, please ensure data is in "
+                        "recordio-protobuf format: {} {}".format(type(e), e))
             else:
-                raise UnsupportedMediaTypeInferenceError("Content type must be csv, libsvm, or recordio-protobuf.")
+                raise UnsupportedMediaTypeInferenceError(
+                    "Content type must be csv, libsvm, or recordio-protobuf.")
 
             return dtest, content_type
 
@@ -187,15 +187,17 @@ class HandlerService(DefaultHandlerService):
             Returns:
                 encoded response for MMS to return to client
             """
+            accept_type = accept.lower()
             try:
-                if accept == content_types.CSV or accept == 'csv':
+                if accept_type == content_types.CSV or accept_type == 'csv':
                     if SAGEMAKER_BATCH:
                         return_data = "\n".join(map(str, prediction.tolist())) + '\n'
                     else:
+                        #FIXME: this is invalid CSV and is only retained for backwards compatibility
                         return_data = ",".join(map(str, prediction.tolist()))
                     encoded_prediction = return_data.encode("utf-8")
-                elif accept == content_types.JSON or accept == 'json':
-                    encoded_prediction = encoder.encode(prediction, accept)
+                elif accept_type == content_types.JSON or accept_type == 'json':
+                    encoded_prediction = encoder.encode(prediction, accept_type)
                 else:
                     raise ValueError("{} is not an accepted Accept type. Please choose one of the following:"
                                      " ['{}', '{}'].".format(accept, content_types.CSV, content_types.JSON))

--- a/test/unit/algorithm_mode/test_handler_service.py
+++ b/test/unit/algorithm_mode/test_handler_service.py
@@ -43,9 +43,17 @@ class FakeEstimator:
         return
 
 
+class FakeData:
+    def __init__(self, array):
+        self.feature_names = array
+
+
 @pytest.mark.parametrize('csv_array', (b'42,6,9', b'42.0,6.0,9.0'))
 def test_input_fn_dmatrix(csv_array):
     deserialized_csv_array, content_type = handler.default_input_fn(csv_array, content_types.CSV)
+    assert type(deserialized_csv_array) is xgb.DMatrix
+
+    deserialized_csv_array, content_type = handler.default_input_fn(csv_array, 'text/CSV;charset=utf-8')
     assert type(deserialized_csv_array) is xgb.DMatrix
 
 
@@ -67,14 +75,27 @@ def test_predict_fn(np_array):
         handler.default_predict_fn((np_array, 'foo_content_type'), (mock_estimator, 'foo_format'))
     mock.assert_called_once()
 
+    mock_estimator2 = FakeEstimator()
+    mock_estimator2.feature_names = np.ones(2)
+    mock_data = FakeData(np.ones(2))
+    with patch.object(mock_estimator2, 'predict') as mock2:
+        handler.default_predict_fn((mock_data, 'text/CSV;charset=utf-8'), (mock_estimator2, 'pkl_format'))
+    mock2.assert_called_once()
+
 
 def test_output_fn_json(np_array):
     response = handler.default_output_fn(np_array, content_types.JSON)
     assert response == encoders.array_to_json(np_array.tolist())
 
+    response = handler.default_output_fn(np_array, content_types.JSON.upper())
+    assert response == encoders.array_to_json(np_array.tolist())
+
 
 def test_output_fn_csv(np_array):
     response = handler.default_output_fn(np_array, content_types.CSV)
+    assert response == b'[1.0, 1.0],[1.0, 1.0]'
+
+    response = handler.default_output_fn(np_array, content_types.CSV.upper())
     assert response == b'[1.0, 1.0],[1.0, 1.0]'
 
 


### PR DESCRIPTION
*Description of changes:*

This commit includes following changes:

1. get_content_type parsed the MIME type to remove optional parameters
from the CSV type. We apply that parsing rule for all content types
allowing optional key-value parameters after the primary type string.
2. Inference handler has been updated to perform case-insensitive
comparison and allow optional parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
