### PR TITLE
Add version for gunicorn.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 PyYAML<4.3
+gunicorn<20.0.0
 matplotlib
 numpy
 pandas>=0.24.0
 psutil==5.4.8  # sagemaker-containers requires psutil 5.4.8
+python-dateutil<2.8.1
 requests<2.21
 retrying==1.3.3
 sagemaker-containers>=2.5.6


### PR DESCRIPTION
*Description of changes:*

Gunicorn 20.0.0 removed some files that were imported in serve.py, namely

```from gunicorn.six import iteritems```

Added version limit in requirements.

*Testing*
```tox```
integration tests all passed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
