### PR TITLE
Fix recordio-protobuf parsing in algorithm mode server.

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/serve_utils.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve_utils.py
@@ -18,7 +18,8 @@ def get_content_type(request):
     content_type = content_type.lower()
     tokens = content_type.split(";")
     content_type = tokens[0].strip()
-    if content_type not in ['text/csv', 'text/libsvm', 'text/x-libsvm']:
+    if content_type not in ['text/csv', 'text/libsvm', 'text/x-libsvm', 'application/x-recordio-protobuf']:
         raise exceptions.UserError("Content-type {} not supported. "
-                                   "Supported content-type is text/csv, text/libsvm".format(content_type))
+                                   "Supported content-type is text/csv, text/libsvm,"
+                                   " application/x-recordio-protobuf".format(content_type))
     return content_type


### PR DESCRIPTION
*Description of changes:*

RecordIO-Protobuf inference requests were getting 'corrupted' due to stripping on byte stream.

*Test*
```tox```
Container tests (pulled from mainline). There are some minor changes that need to be made to container tests, review following shortly.
Integration tests passing except (subsampling, parameter tuning).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
