### PR TITLE
Update sagemaker-inference and MMS version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ python-dateutil==2.8.0
 requests<2.21
 retrying==1.3.3
 sagemaker-containers>=2.5.6
-sagemaker-inference==1.0.5
+sagemaker-inference==1.1.2
 scikit-learn
 scipy
 urllib3<1.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML<4.3
 matplotlib
 model-archiver
-mxnet-model-server==1.0.8
+multi-model-server==1.0.8.1
 numpy
 pandas>=0.24.0
 psutil==5.4.8  # sagemaker-containers requires psutil 5.4.8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,7 @@ python-dateutil==2.8.0
 requests<2.21
 sagemaker>=1.3.0
 sagemaker-containers>=2.5.6
-sagemaker-inference==1.0.4
+sagemaker-inference==1.1.2
 tox
 tox-conda
 xgboost==0.90

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ coverage
 docker-compose
 flake8
 mock
-mxnet-model-server==1.0.8
+multi-model-server==1.0.8.1
 pytest
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
Version 1.0.5 does not exist, so update to 1.1.2.

*Issue #, if available:*

*Description of changes:*
Version 1.0.5 does not exist, so update to 1.1.2.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
