### PR TITLE
Add support to parse MAX_CONTENT_LENGTH during inference.

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/serve.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve.py
@@ -35,7 +35,7 @@ SAGEMAKER_BATCH = os.getenv("SAGEMAKER_BATCH")
 logging = integration.setup_main_logger(__name__)
 
 
-def _get_max_content_size():
+def _get_max_content_length():
     max_payload_size = 20 * 1024 ** 2
     # NOTE: 6 MB max content length = 6 * 1024 ** 2
     content_len = int(os.getenv("MAX_CONTENT_LENGTH", '6291456'))
@@ -45,7 +45,7 @@ def _get_max_content_size():
         return max_payload_size
 
 
-PARSED_MAX_CONTENT_LENGTH = _get_max_content_size()
+PARSED_MAX_CONTENT_LENGTH = _get_max_content_length()
 
 
 def number_of_workers():

--- a/test/unit/algorithm_mode/test_serve.py
+++ b/test/unit/algorithm_mode/test_serve.py
@@ -12,7 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-from mock import MagicMock
+import json
+from mock import MagicMock, patch
 import pytest
 
 from sagemaker_algorithm_toolkit import exceptions as exc
@@ -57,3 +58,20 @@ def test_incorrect_content_type(incorrect_content_type):
 
     with pytest.raises(exc.UserError):
         serve._parse_content_data(mock_request)
+
+
+def test_default_execution_parameters():
+    execution_parameters_response = serve.execution_parameters()
+
+    parsed_exec_params_response = json.loads(execution_parameters_response.response[0])
+    assert parsed_exec_params_response['MaxPayloadInMB'] == 6
+    assert parsed_exec_params_response["BatchStrategy"] == "MULTI_RECORD"
+
+
+@patch('sagemaker_xgboost_container.algorithm_mode.serve.PARSED_MAX_CONTENT_LENGTH', 19 * 1024 ** 2)
+def test_max_execution_parameters():
+    execution_parameters_response = serve.execution_parameters()
+
+    parsed_exec_params_response = json.loads(execution_parameters_response.response[0])
+    assert parsed_exec_params_response['MaxPayloadInMB'] == 19
+    assert parsed_exec_params_response["BatchStrategy"] == "MULTI_RECORD"


### PR DESCRIPTION
*Description of changes:*

Increase max content length up to 20MB based one user defined environment variable/

*Tests run*
```tox```
Containers tests and integration tests pass


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
