### PR TITLE
Fix incorrect keyword argument in DMatrix creation

### DIFF
--- a/src/sagemaker_xgboost_container/data_utils.py
+++ b/src/sagemaker_xgboost_container/data_utils.py
@@ -323,7 +323,7 @@ def _get_csv_dmatrix_pipe_mode(pipe_path, csv_weights):
             del examples
 
             if csv_weights == 1:
-                dmatrix = xgb.DMatrix(data[:, 2:], label=data[:, 0], weights=data[:, 1])
+                dmatrix = xgb.DMatrix(data[:, 2:], label=data[:, 0], weight=data[:, 1])
             else:
                 dmatrix = xgb.DMatrix(data[:, 1:], label=data[:, 0])
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The instance weight parameter is incorrectly called weights in the DMatrix creation. As a result, if customers specify csv_weights=1 the container fails with algorithm error TypeError: __init__() got an unexpected keyword argument 'weights'

https://xgboost.readthedocs.io/en/release_0.90/python/python_api.html#xgboost.DMatrix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
