### PR TITLE
Use Python 3.6 installed with conda

### DIFF
--- a/docker/0.90-2/base/Dockerfile.cpu
+++ b/docker/0.90-2/base/Dockerfile.cpu
@@ -2,28 +2,32 @@ FROM ubuntu:16.04
 
 # Install python and other runtime dependencies
 RUN apt-get update && \
-    apt-get -y install build-essential libatlas-dev git wget curl nginx jq && \
-    apt-get -y install python3-dev python3-setuptools
-
-# Install pip
-RUN cd /tmp && \
-     curl -O https://bootstrap.pypa.io/get-pip.py && \
-     python3 get-pip.py && \
-     rm get-pip.py
+    apt-get -y install \
+        build-essential \
+        libatlas-dev \
+        git \
+        wget \
+        curl \
+        nginx \
+        jq
 
 # Install mlio
-RUN echo 'installing miniconda'
-RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-RUN bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3
-RUN rm Miniconda3-latest-Linux-x86_64.sh
+RUN echo 'installing miniconda' && \
+    curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3 && \
+    rm Miniconda3-latest-Linux-x86_64.sh
+
 ENV PATH=/miniconda3/bin:${PATH}
-RUN conda update -y conda
-RUN conda install -c conda-forge pyarrow=0.14.1
-RUN conda install -c mlio -c conda-forge mlio-py=0.1
+
+RUN conda install python=3.6 && \
+    conda update -y conda && \
+    conda install -c conda-forge pyarrow=0.14.1 && \
+    conda install -c mlio -c conda-forge mlio-py=0.1
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING='utf-8'
 
 # Install latest version of XGBoost

--- a/docker/0.90-2/final/Dockerfile.cpu
+++ b/docker/0.90-2/final/Dockerfile.cpu
@@ -15,14 +15,14 @@ ENV SAGEMAKER_TRAINING_MODULE sagemaker_xgboost_container.training:main
 ENV SAGEMAKER_SERVING_MODULE sagemaker_xgboost_container.serving:main
 
 # Include DMLC python code in PYTHONPATH to use RabitTracker
-ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.5/dist-packages/xgboost/dmlc-core/tracker
+ENV PYTHONPATH=$PYTHONPATH:/miniconda3/lib/python3.6/site-packages/xgboost/dmlc-core/tracker
 
 COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt && rm /requirements.txt
 
 # DMLC patches; TODO: remove after making contributions back to xgboost for tracker.py
 COPY src/sagemaker_xgboost_container/dmlc_patch/tracker.py \
-   /usr/local/lib/python3.5/dist-packages/xgboost/dmlc-core/tracker/dmlc_tracker/tracker.py
+   /miniconda3/lib/python3.6/site-packages/xgboost/dmlc-core/tracker/dmlc_tracker/tracker.py
 
 COPY dist/sagemaker_xgboost_container-2.0-py2.py3-none-any.whl /sagemaker_xgboost_container-2.0-py2.py3-none-any.whl
 RUN pip install --no-cache /sagemaker_xgboost_container-2.0-py2.py3-none-any.whl && \

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 
     install_requires=read("requirements.txt"),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Similar to #45 but I think upgrading to Python 3.6 is a better solution because:

1. Came across [this issue](https://github.com/apache/incubator-superset/issues/8349) and it looks like Gunicorn is recommending 3.6 because they test against 3.6,
2. SageMaker uses 3.6 currently.

Tests: flake8, pytest test/unit, internal functional tests, all internal integration tests pass except HPO.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
