### PR TITLE
Fix script mode training hang with logging enabled

### DIFF
--- a/src/sagemaker_xgboost_container/training.py
+++ b/src/sagemaker_xgboost_container/training.py
@@ -82,7 +82,7 @@ def train(training_environment):
         logger.info('Invoking user training script.')
         framework.modules.run_module(training_environment.module_dir, training_environment.to_cmd_args(),
                                      training_environment.to_env_vars(), training_environment.module_name,
-                                     capture_error=True)
+                                     capture_error=False)
     else:
         logger.info("Running XGBoost Sagemaker in algorithm mode")
         _env.write_env_vars(training_environment.to_env_vars())


### PR DESCRIPTION
*Description of changes:*
A user discovered that after a recent release, their training script stops to work when adding a stdout stream handler to the logger. The issue was traced back to [this commit](https://github.com/aws/sagemaker-containers/commit/f4d3456e912c2800103f21211df21df278cf6aab) in sagemaker-containers.

`capture_error=True` appends stderr to the error message that gets thrown if training fails. For context, this was specifically a workaround for PyTorch, which can throw a specific error even if training succeeds, so I don't believe this is necessary for XGBoost.

Corresponding PR for 0.90-2: https://github.com/aws/sagemaker-xgboost-container/pull/78

*Testing:*
Using the prod image with capture_error enabled, the training script would hang with no log output. With capture_error disabled on a custom image, I was able to complete the training job successfully with the expected log output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
