### PR TITLE
Fix training unit test to match PR #77.

### DIFF
--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -30,7 +30,7 @@ class TestTraining(unittest.TestCase):
         training.train(env)
 
         mock_run_module.assert_called_with(
-            's3://my/script', env.to_cmd_args(), env.to_env_vars(), 'svm', capture_error=True)
+            's3://my/script', env.to_cmd_args(), env.to_env_vars(), 'svm', capture_error=False)
 
     @patch('sagemaker_xgboost_container.training.run_algorithm_mode')
     def test_algorithm_mode(self, mock_algorithm_mode_train):


### PR DESCRIPTION
*Description of changes:*
This PR updates the parameter in test_training.py to match PR #77's change: `capture_error=True` -> `capture_error=False`.

*Testing:*
`tox` run, tests passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
