### PR TITLE
Add verbosity to hyperparameter validation.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ requests<2.21
 retrying==1.3.3
 sagemaker-containers>=2.5.6
 scikit-learn
-scipy
+scipy==1.2.2
 urllib3<1.25
 wheel

--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -109,6 +109,7 @@ def initialize(metrics):
         hpv.IntegerHyperparameter(name="early_stopping_rounds", range=hpv.Interval(min_closed=1), required=False),
         hpv.CategoricalHyperparameter(name="booster", range=["gbtree", "gblinear", "dart"], required=False),
         hpv.IntegerHyperparameter(name="silent", range=hpv.Interval(min_closed=0, max_closed=1), required=False),
+        hpv.IntegerHyperparameter(name="verbosity", range=hpv.Interval(min_closed=0, max_closed=3), required=False),
         hpv.IntegerHyperparameter(name="nthread", range=hpv.Interval(min_closed=1), required=False),
         hpv.ContinuousHyperparameter(name="eta", range=hpv.Interval(min_closed=0, max_closed=1), required=False,
                                      tunable=True,

--- a/test/unit/algorithm_mode/test_hyperparameter_validation.py
+++ b/test/unit/algorithm_mode/test_hyperparameter_validation.py
@@ -43,3 +43,23 @@ class TestHyperparameterValidation(unittest.TestCase):
 
             with self.assertRaises(exc.UserError):
                 hyperparameters.validate(test_hp)
+
+    def test_verbosity(self):
+        test_hp = {
+            'num_round': '1',
+            'verbosity': '0'}
+
+        assert hyperparameters.validate(test_hp)
+
+        test_hp2 = {
+            'num_round': '1',
+            'verbosity': '3'}
+
+        assert hyperparameters.validate(test_hp2)
+
+        test_hp3 = {
+            'num_round': '1',
+            'verbosity': '4'}
+
+        with self.assertRaises(exc.UserError):
+            hyperparameters.validate(test_hp3)


### PR DESCRIPTION
*Description of changes:*
Added `verbosity` to hyperparameter validation. See [docs](https://xgboost.readthedocs.io/en/latest/parameter.html#general-parameters) for info. Simple unit test added.

EDIT: scipy version locked to 1.2.2 due to requirement of sagemaker-containers 2.6.2

*Testing:*
`tox` + all container and integration tests run and passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
