### PR TITLE
Bump psutil and sagemaker-containers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ gunicorn<20.0.0
 matplotlib
 numpy
 pandas>=0.24.0
-psutil==5.4.8  # sagemaker-containers requires psutil 5.4.8
+psutil==5.6.7  # sagemaker-containers requires psutil 5.6.7
 python-dateutil==2.8.0
 requests<2.21
 retrying==1.3.3
-sagemaker-containers>=2.5.6
+sagemaker-containers>=2.8.3
 scikit-learn
 scipy==1.2.2
 smdebug==0.4.13


### PR DESCRIPTION
Bump psutil from 5.4.8 to 5.6.7 and sagemaker-containers from 2.5.6 to 2.8.3

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
