### PR TITLE
Document csv decoder error

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/serve.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve.py
@@ -266,9 +266,10 @@ def invocations():
         logging.exception(e)
         return flask.Response(response="Unable to evaluate payload provided: %s" % e, status=http.client.BAD_REQUEST)
 
-    return_data = ",".join(map(str, preds.tolist()))
     if SAGEMAKER_BATCH:
         return_data = "\n".join(map(str, preds.tolist())) + '\n'
+    else:
+        return_data = ",".join(map(str, preds.tolist()))
 
     return flask.Response(response=return_data, status=http.client.OK, mimetype="text/csv")
 

--- a/src/sagemaker_xgboost_container/encoder.py
+++ b/src/sagemaker_xgboost_container/encoder.py
@@ -36,7 +36,7 @@ def _clean_csv_string(csv_string, delimiter):
 def csv_to_dmatrix(string_like, dtype=None):  # type: (str) -> xgb.DMatrix
     """Convert a CSV object to a DMatrix object.
     Args:
-        string_like (str): CSV string.
+        string_like (str): CSV string. Assumes the string has been stripped of leading or trailing newline chars.
         dtype (dtype, optional):  Data type of the resulting array. If None, the dtypes will be determined by the
                                         contents of each column, individually. This argument can only be used to
                                         'upcast' the array.  For downcasting, use the .astype(t) method.

--- a/src/sagemaker_xgboost_container/serving.py
+++ b/src/sagemaker_xgboost_container/serving.py
@@ -46,6 +46,8 @@ def default_input_fn(input_data, content_type):
             - The request Content-Type, for example "application/json"
             - The request data, which is at most 5 MB (5 * 1024 * 1024 bytes) in size.
         The input_fn is responsible to take the request data and pre-process it before prediction.
+        Note: For CSV data, the decoder will error if there are any leading or trailing newline
+        chars.
     Args:
         input_data (obj): the request data.
         content_type (str): the request Content-Type.


### PR DESCRIPTION
Changes:
* Document csv decoder error for script mode.
* Avoid writing prediction to string twice during batch transform.

Changes tested by running `tox -r`, all tests passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
