### PR TITLE
change: Use sagemaker-training for training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ python-dateutil==2.8.0
 requests<2.21
 retrying==1.3.3
 sagemaker-containers>=2.8.3
+sagemaker-training>=3.4.2
 scikit-learn
 scipy==1.2.2
 smdebug==0.4.13

--- a/src/sagemaker_xgboost_container/training.py
+++ b/src/sagemaker_xgboost_container/training.py
@@ -17,8 +17,7 @@ import logging
 import os
 import sys
 
-from sagemaker_containers import _env
-import sagemaker_containers.beta.framework as framework
+from sagemaker_training import entry_point, environment
 from sagemaker_xgboost_container.algorithm_mode.train import sagemaker_train
 from sagemaker_xgboost_container.constants import sm_env_constants
 
@@ -80,16 +79,18 @@ def train(training_environment):
     """
     if training_environment.user_entry_point is not None:
         logger.info('Invoking user training script.')
-        framework.modules.run_module(training_environment.module_dir, training_environment.to_cmd_args(),
-                                     training_environment.to_env_vars(), training_environment.module_name,
-                                     capture_error=False)
+        entry_point.run(uri=training_environment.module_dir,
+                        user_entry_point=training_environment.module_name,
+                        args=training_environment.to_cmd_args(),
+                        env_vars=training_environment.to_env_vars(),
+                        capture_error=False)
     else:
         logger.info("Running XGBoost Sagemaker in algorithm mode")
-        _env.write_env_vars(training_environment.to_env_vars())
+        environment.write_env_vars(training_environment.to_env_vars())
 
         run_algorithm_mode()
 
 
 def main():
-    train(framework.training_env())
+    train(environment.Environment())
     sys.exit(0)

--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -23,14 +23,17 @@ def mock_training_env(current_host='algo-1', module_dir='s3://my/script', module
 class TestTraining(unittest.TestCase):
     """Note: The 'train' method has been mocked since this test only checks the training resource setup"""
 
-    @patch('sagemaker_containers.beta.framework.modules.run_module')
+    @patch('sagemaker_training.entry_point.run')
     def test_script_mode(self, mock_run_module):
         env = mock_training_env()
         env.user_entry_point = "dummy_entry_point"
         training.train(env)
 
-        mock_run_module.assert_called_with(
-            's3://my/script', env.to_cmd_args(), env.to_env_vars(), 'svm', capture_error=False)
+        mock_run_module.assert_called_with(uri='s3://my/script',
+                                           user_entry_point='svm',
+                                           args=env.to_cmd_args(),
+                                           env_vars=env.to_env_vars(),
+                                           capture_error=False)
 
     @patch('sagemaker_xgboost_container.training.run_algorithm_mode')
     def test_algorithm_mode(self, mock_algorithm_mode_train):


### PR DESCRIPTION
*Description of changes:*
This PR replaces the deprecated [sagemaker-containers](https://github.com/aws/sagemaker-containers) package with the new [sagemaker-training](https://github.com/aws/sagemaker-training-toolkit) package for training functionality.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
