### PR TITLE
Add support for hyperparameter aliases

### DIFF
--- a/src/sagemaker_algorithm_toolkit/hyperparameter_validation.py
+++ b/src/sagemaker_algorithm_toolkit/hyperparameter_validation.py
@@ -179,6 +179,7 @@ class CommaSeparatedListHyperparameter(Hyperparameter):
 class Hyperparameters(object):
     def __init__(self, *hyperparameters):
         self.hyperparameters = {hyperparameter.name: hyperparameter for hyperparameter in hyperparameters}
+        self.aliases = {}
 
     def _sort_dependencies(self, hyperparameters):
         dependencies_stack = []
@@ -198,8 +199,26 @@ class Hyperparameters(object):
 
         return dependencies_stack
 
+    def declare_alias(self, key_name, alias_name):
+        if key_name not in self.hyperparameters:
+            raise exc.AlgorithmError("Key name {}: does not exist in list of hyperparameters".format(key_name))
+
+        self.aliases[alias_name] = key_name
+
+    def _replace_aliases(self, user_hyperparameters):
+        tmp_user_hyperparamers = {}
+        for hp, value in user_hyperparameters.items():
+            if hp in self.aliases:
+                hp = self.aliases.get(hp)
+            tmp_user_hyperparamers[hp] = value
+
+        return tmp_user_hyperparamers
+
     def validate(self, user_hyperparameters):
-        # NOTE: 0. Validate required or fill in default.
+        # NOTE: 0. Replace aliases with original keys.
+        user_hyperparameters = self._replace_aliases(user_hyperparameters)
+
+        # NOTE: 1. Validate required or fill in default.
         for hp in self.hyperparameters:
             if hp not in user_hyperparameters:
                 if self.hyperparameters[hp].required:
@@ -207,7 +226,7 @@ class Hyperparameters(object):
                 elif self.hyperparameters[hp].default is not None:
                     user_hyperparameters[hp] = self.hyperparameters[hp].default
 
-        # NOTE: 1. Convert hyperparameters.
+        # NOTE: 2. Convert hyperparameters.
         converted_hyperparameters = {}
         for hp, value in user_hyperparameters.items():
             try:
@@ -219,7 +238,7 @@ class Hyperparameters(object):
             except ValueError as e:
                 raise exc.UserError("Hyperparameter {}: could not parse value".format(hp), caused_by=e)
 
-        # NOTE: 2. Validate range.
+        # NOTE: 3. Validate range.
         for hp, value in converted_hyperparameters.items():
             try:
                 self.hyperparameters[hp].validate_range(value)
@@ -229,7 +248,7 @@ class Hyperparameters(object):
                 raise exc.AlgorithmError("Hyperparameter {}: unexpected failure when validating {}".format(hp, value),
                                          caused_by=e)
 
-        # NOTE: 3. Validate dependencies.
+        # NOTE: 4. Validate dependencies.
         sorted_deps = self._sort_dependencies(converted_hyperparameters.keys())
         new_validated_hyperparameters = {}
         while sorted_deps:

--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -204,4 +204,10 @@ def initialize(metrics):
         hpv.IntegerHyperparameter(name="seed", range=hpv.Interval(min_open=-2**31, max_open=2**31-1),
                                   required=False),
         )
+
+    hyperparameters.declare_alias("eta", "learning_rate")
+    hyperparameters.declare_alias("gamma", "min_split_loss")
+    hyperparameters.declare_alias("lambda", "reg_lambda")
+    hyperparameters.declare_alias("alpha", "reg_alpha")
+
     return hyperparameters

--- a/test/unit/algorithm_mode/test_algorithm_mode.py
+++ b/test/unit/algorithm_mode/test_algorithm_mode.py
@@ -85,6 +85,64 @@ class TestAlgorithmModeHyperparameters(unittest.TestCase):
         hps = hpv.initialize(self.metrics)
         hps.validate(hyperparameters)
 
+    def test_hyperparameters5(self):
+        hyperparameters = {
+            "max_depth": "5",
+            "learning_rate": "0.2",
+            "gamma": "4",
+            "min_child_weight": "6",
+            "tree_method": "approx",
+            "objective": "multi:softmax",
+            "num_class": "10",
+            "num_round": "10"
+        }
+        hps = hpv.initialize(self.metrics)
+        hps.validate(hyperparameters)
+
+    def test_hyperparameters6(self):
+        hyperparameters = {
+            "max_depth": "5",
+            "eta": "0.2",
+            "min_split_loss": "4",
+            "min_child_weight": "6",
+            "tree_method": "approx",
+            "objective": "multi:softmax",
+            "num_class": "10",
+            "num_round": "10"
+        }
+        hps = hpv.initialize(self.metrics)
+        hps.validate(hyperparameters)
+
+    def test_hyperparameters7(self):
+        hyperparameters = {
+            "max_depth": "5",
+            "eta": "0.2",
+            "gamma": "4",
+            "reg_lambda": "10",
+            "min_child_weight": "6",
+            "silent": "0",
+            "objective": "multi:softmax",
+            "num_class": "10",
+            "num_round": "10"
+        }
+        hps = hpv.initialize(self.metrics)
+        hps.validate(hyperparameters)
+
+    def test_hyperparameters8(self):
+        hyperparameters = {
+            "max_depth": "5",
+            "eta": "0.2",
+            "gamma": "4",
+            "reg_alpha": "10",
+            "min_child_weight": "6",
+            "silent": "0",
+            "objective": "multi:softmax",
+            "num_class": "10",
+            "num_round": "10"
+        }
+        hps = hpv.initialize(self.metrics)
+        hps.validate(hyperparameters)
+
 
 class TestAlgorithmModeChannels(unittest.TestCase):
     def setUp(self):

--- a/test/unit/algorithm_toolkit/test_hyperparameter_validation.py
+++ b/test/unit/algorithm_toolkit/test_hyperparameter_validation.py
@@ -165,3 +165,51 @@ class TestHyperparameters(unittest.TestCase):
                                                          'MinValue': '0',
                                                          'Name': 'x',
                                                          'ScalingType': 'Linear'}]})
+
+    def test_simple_alias(self):
+        hps = hpv.Hyperparameters(hpv.ContinuousHyperparameter(name="gamma",
+                                                               range=hpv.Interval(min_closed=0, max_closed=1),
+                                                               required=True))
+        hps.declare_alias("gamma", "min_split_loss")
+
+        with self.assertRaises(exc.UserError):
+            hps.validate({})
+
+        with self.assertRaises(exc.UserError):
+            hps.validate({"min_split_long": "0.5"})
+
+        result = hps.validate({"min_split_loss": "0.667"})
+        self.assertEqual(result["gamma"], 0.667)
+
+    def test_multiple_alias(self):
+        hps = hpv.Hyperparameters(hpv.ContinuousHyperparameter(name="a", default=0.5,
+                                                               range=hpv.Interval(min_closed=0, max_closed=1),
+                                                               required=True))
+        hps.declare_alias("a", "alpha")
+        hps.declare_alias("a", "beta")
+
+        with self.assertRaises(exc.UserError):
+            hps.validate({})
+
+        with self.assertRaises(exc.UserError):
+            hps.validate({"abc": "0.5"})
+
+        result = hps.validate({"alpha": "0.667"})
+        self.assertEqual(result["a"], 0.667)
+
+        result = hps.validate({"beta": "0.667"})
+        self.assertEqual(result["a"], 0.667)
+
+    def test_empty_alias(self):
+        hps = hpv.Hyperparameters(hpv.ContinuousHyperparameter(name="a",
+                                                               range=hpv.Interval(min_closed=0, max_closed=1),
+                                                               required=False))
+
+        with self.assertRaises(exc.AlgorithmError):
+            hps.declare_alias("b", "c")
+
+        with self.assertRaises(exc.UserError):
+            hps.validate({"abc": "0.5"})
+
+        result = hps.validate({"a": "0.667"})
+        self.assertEqual(result["a"], 0.667)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Adds support for following hyperparameters and aliases:

   - **_eta -> learning_rate_**
   - **_gamma -> min_split_loss_**
   - **_lambda -> reg_lambda_**
   - **_alpha -> reg_alpha_**

Tested with `tox` and integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
