### PR TITLE
Add num_parallel_tree parameter

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -222,6 +222,7 @@ def initialize(metrics):
                                              required=False),
         hpv.IntegerHyperparameter(name="seed", range=hpv.Interval(min_open=-2**31, max_open=2**31-1),
                                   required=False),
+        hpv.IntegerHyperparameter(name="num_parallel_tree", range=hpv.Interval(min_closed=1), required=False)
         )
 
     hyperparameters.declare_alias("eta", "learning_rate")

--- a/test/unit/algorithm_mode/test_hyperparameter_validation.py
+++ b/test/unit/algorithm_mode/test_hyperparameter_validation.py
@@ -63,3 +63,27 @@ class TestHyperparameterValidation(unittest.TestCase):
 
         with self.assertRaises(exc.UserError):
             hyperparameters.validate(test_hp3)
+
+    def test_num_parallel_tree(self):
+        test_hp = {
+            'num_round': '5',
+            'num_parallel_tree': '10'
+        }
+
+        assert hyperparameters.validate(test_hp)
+
+        test_hp2 = {
+            'num_round': '5',
+            'num_parallel_tree': '-1'
+        }
+
+        with self.assertRaises(exc.UserError):
+            hyperparameters.validate(test_hp2)
+
+        test_hp3 = {
+            'num_round': '5',
+            'num_parallel_tree': '0'
+        }
+
+        with self.assertRaises(exc.UserError):
+            hyperparameters.validate(test_hp3)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add num_parallel_tree hyperparameter to validation

Tested
tox -e py3-xgboost1.0,flake8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
