### PR TITLE
fix: change parse accept type logic when accept not set

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/serve.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve.py
@@ -165,15 +165,9 @@ def _parse_accept(request):
     :param request: flask request
     :return: parsed accept type
     """
-    default_accept = os.getenv('SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT')
-    try:
-        accept, _ = cgi.parse_header(request.headers.get("accept", default_accept))
-    except Exception:
-        raise RuntimeError("Cannot parse accept type. Please specify an accept type "
-                           "from the supported accept types: {}.".format(SUPPORTED_ACCEPTS))
-    if not accept:
-        raise ValueError("Accept type not set. Please specify an accept type from the supported accept types: {}."
-                         .format(SUPPORTED_ACCEPTS))
+    accept, _ = cgi.parse_header(request.headers.get("accept", ""))
+    if not accept or accept == "*/*":
+        return os.getenv(sm_env_constants.SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT, "text/csv")
     if accept.lower() not in SUPPORTED_ACCEPTS:
         raise ValueError("Accept type {} is not supported. Please use supported accept types: {}."
                          .format(accept, SUPPORTED_ACCEPTS))

--- a/test/unit/algorithm_mode/test_serve.py
+++ b/test/unit/algorithm_mode/test_serve.py
@@ -50,16 +50,8 @@ def test_parse_accept_default(monkeypatch):
     assert serve._parse_accept(mock_request) == 'text/csv'
 
 
-@pytest.mark.parametrize('accept', ['text/libsvm', ''])
-def test_parse_accept_incompatible(accept):
+def test_parse_accept_incompatible():
     mock_request = MagicMock()
-    mock_request.headers.get.return_value = accept
+    mock_request.headers.get.return_value = 'text/libsvm'
     with pytest.raises(ValueError):
-        serve._parse_accept(mock_request)
-
-
-def test_parse_accept_none():
-    mock_request = MagicMock()
-    mock_request.headers = {}
-    with pytest.raises(RuntimeError):
         serve._parse_accept(mock_request)

--- a/test/unit/algorithm_mode/test_serve.py
+++ b/test/unit/algorithm_mode/test_serve.py
@@ -50,8 +50,16 @@ def test_parse_accept_default(monkeypatch):
     assert serve._parse_accept(mock_request) == 'text/csv'
 
 
-def test_incompatible_parse_accept():
+@pytest.mark.parametrize('accept', ['text/libsvm', ''])
+def test_parse_accept_incompatible(accept):
     mock_request = MagicMock()
-    mock_request.headers.get.return_value = 'text/libsvm'
+    mock_request.headers.get.return_value = accept
     with pytest.raises(ValueError):
+        serve._parse_accept(mock_request)
+
+
+def test_parse_accept_none():
+    mock_request = MagicMock()
+    mock_request.headers = {}
+    with pytest.raises(RuntimeError):
         serve._parse_accept(mock_request)

--- a/test/unit/algorithm_mode/test_serve.py
+++ b/test/unit/algorithm_mode/test_serve.py
@@ -43,6 +43,13 @@ def test_parse_accept():
     assert serve._parse_accept(mock_request) == 'application/json'
 
 
+def test_parse_accept_default(monkeypatch):
+    mock_request = MagicMock()
+    mock_request.headers = {}
+    monkeypatch.setenv('SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT', 'text/csv')
+    assert serve._parse_accept(mock_request) == 'text/csv'
+
+
 def test_incompatible_parse_accept():
     mock_request = MagicMock()
     mock_request.headers.get.return_value = 'text/libsvm'


### PR DESCRIPTION
*Description of changes:*
* This change is to fix the behavior when `accept` is not specified in the header of the request (occurs during batch transform)
  * If `accept` is not specified or "\*/\*", it should default to `SAGEMAKER_DEFAULT_INVOCATIONS_ACCEPT` env var
* Previous logic would cause a `'NoneType' object has no attribute 'lower'` error


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
