### PR TITLE
fix: bug for custom metric calculations for multi:softprob

### DIFF
--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -23,7 +23,7 @@ def accuracy(preds, dtrain):
     :return: Metric name, accuracy value.
     """
     labels = dtrain.get_label()
-    rounded_preds = [round(np.max(value)) if (type(value) is np.ndarray) else round(value) for value in preds]
+    rounded_preds = [np.argmax(value) if (type(value) is np.ndarray) else round(value) for value in preds]
     return 'accuracy', accuracy_score(labels, rounded_preds)
 
 

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -37,7 +37,7 @@ def f1(preds, dtrain):
     :return: Metric name, f1 score
     """
     labels = dtrain.get_label()
-    rounded_preds = [round(np.max(value)) if (type(value) is np.ndarray) else round(value) for value in preds]
+    rounded_preds = [np.argmax(value) if (type(value) is np.ndarray) else round(value) for value in preds]
     return 'f1', f1_score(labels, rounded_preds, average='macro')
 
 

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -44,12 +44,19 @@ multiclass_train_data = np.random.rand(10, 2)
 multiclass_train_label = np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])
 multiclass_dtrain = xgb.DMatrix(multiclass_train_data, label=multiclass_train_label)
 multiclass_preds = np.ones(10)
+multiclass_preds_softprob = np.asarray([[0.8, 0.1, 0.1]] * 10)
 
 
 def test_multiclass_accuracy():
     accuracy_name, accuracy_result = accuracy(multiclass_preds, multiclass_dtrain)
     assert accuracy_name == 'accuracy'
     assert accuracy_result == .5
+
+
+def test_multiclass_accuracy_softprob():
+    accuracy_name, accuracy_result = accuracy(multiclass_preds_softprob, multiclass_dtrain)
+    assert accuracy_name == 'accuracy'
+    assert accuracy_result == .2
 
 
 def test_multiclass_f1():

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -57,7 +57,16 @@ multiclass_train_data = np.random.rand(10, 2)
 multiclass_train_label = np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])
 multiclass_dtrain = xgb.DMatrix(multiclass_train_data, label=multiclass_train_label)
 multiclass_preds = np.ones(10)
-multiclass_preds_softprob = np.asarray([[0.8, 0.1, 0.1]] * 10)
+multiclass_preds_softprob = np.asarray([[0.9, 0.05, 0.05],
+                                        [0.4, 0.5, 0.1],
+                                        [0.2, 0.1, 0.7],
+                                        [0.8, 0.1, 0.1],
+                                        [0.6, 0.2, 0.2],
+                                        [0.9, 0.08, 0.02],
+                                        [0.4, 0.3, 0.3],
+                                        [0.5, 0.25, 0.25],
+                                        [0.8, 0.1, 0.1],
+                                        [0.6, 0.2, 0.2]])
 
 
 def test_multiclass_accuracy():
@@ -69,7 +78,7 @@ def test_multiclass_accuracy():
 def test_multiclass_accuracy_softprob():
     accuracy_name, accuracy_result = accuracy(multiclass_preds_softprob, multiclass_dtrain)
     assert accuracy_name == 'accuracy'
-    assert accuracy_result == .2
+    assert accuracy_result == .1
 
 
 def test_multiclass_f1():
@@ -81,4 +90,4 @@ def test_multiclass_f1():
 def test_multiclass_f1_softprob():
     f1_score_name, f1_score_result = f1(multiclass_preds_softprob, multiclass_dtrain)
     assert f1_score_name == 'f1'
-    assert f1_score_result == 0.11111111111111112
+    assert f1_score_result == 1/15

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -63,3 +63,9 @@ def test_multiclass_f1():
     f1_score_name, f1_score_result = f1(multiclass_preds, multiclass_dtrain)
     assert f1_score_name == 'f1'
     assert f1_score_result == 2/9
+
+
+def test_multiclass_f1_softprob():
+    f1_score_name, f1_score_result = accuracy(multiclass_preds_softprob, multiclass_dtrain)
+    assert f1_score_name == 'f1'
+    assert f1_score_result == 0.11111111111111112

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -66,6 +66,6 @@ def test_multiclass_f1():
 
 
 def test_multiclass_f1_softprob():
-    f1_score_name, f1_score_result = accuracy(multiclass_preds_softprob, multiclass_dtrain)
+    f1_score_name, f1_score_result = f1(multiclass_preds_softprob, multiclass_dtrain)
     assert f1_score_name == 'f1'
     assert f1_score_result == 0.11111111111111112

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -20,6 +20,7 @@ binary_train_data = np.random.rand(10, 2)
 binary_train_label = np.array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0])
 binary_dtrain = xgb.DMatrix(binary_train_data, label=binary_train_label)
 binary_preds = np.ones(10)
+binary_preds_logistic = np.asarray([[0.1, 0.9]] * 10)
 
 
 def test_binary_accuracy():
@@ -28,8 +29,20 @@ def test_binary_accuracy():
     assert accuracy_result == .5
 
 
+def test_binary_accuracy_logistic():
+    accuracy_name, accuracy_result = accuracy(binary_preds_logistic, binary_dtrain)
+    assert accuracy_name == 'accuracy'
+    assert accuracy_result == .5
+
+
 def test_binary_f1():
     f1_score_name, f1_score_result = f1(binary_preds, binary_dtrain)
+    assert f1_score_name == 'f1'
+    assert f1_score_result == 1/3
+
+
+def test_binary_f1_logistic():
+    f1_score_name, f1_score_result = f1(binary_preds_logistic, binary_dtrain)
     assert f1_score_name == 'f1'
     assert f1_score_result == 1/3
 


### PR DESCRIPTION
*Description of changes:*
* bug fix for custom accuracy metric calculations for `multi:softprob`
* While running benchmarks on HPO, we ran into an issue where multiclass problem types would perform significantly worse with `multi:softprob` compared to using the `multi:softmax` objective
* also affects `binary:logistic`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
