### PR TITLE
Move nloglik metrics to XGB_MINIMIZE_METRICS

### DIFF
--- a/src/sagemaker_xgboost_container/constants/xgb_constants.py
+++ b/src/sagemaker_xgboost_container/constants/xgb_constants.py
@@ -15,25 +15,25 @@ XGB_MAXIMIZE_METRICS = [
     'accuracy',
     'auc',
     'aucpr',
-    "cox-nloglik",
     'f1',
-    "gamma-nloglik",
     'map',
-    'ndcg',
-    "poisson-nloglik",
-    "tweedie-nloglik"
+    'ndcg'
 ]
 
 XGB_MINIMIZE_METRICS = [
+    'cox-nloglik',
     'error',
-    "gamma-deviance",
+    'gamma-deviance',
+    'gamma-nloglik',
     'logloss',
     'mae',
     'merror',
     'mlogloss',
     'mse',
+    'poisson-nloglik',
     'rmse',
-    'rmsle'
+    'rmsle',
+    'tweedie-nloglik'
 ]
 
 LOGISTIC_REGRESSION_LABEL_RANGE_ERROR = "label must be in [0,1] for logistic regression"


### PR DESCRIPTION
*Description of changes:*
Negative log likelihood is a metric that should be minimized, not maximized. [This article](https://medium.com/deeplearningmadeeasy/negative-log-likelihood-6bd79b55d8b6) has a simple explanation for what it is.

This PR moves the `*-nloglik` metrics from the `XGB_MAXIMIZE_METRICS` list to `XGB_MINIMIZE_METRICS`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
