### PR TITLE
Update pickle protocol version to handle large model sizes.

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -237,5 +237,6 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, model_dir, checkpoint_dir, 
 
     if is_master:
         model_location = model_dir + '/xgboost-model'
-        pkl.dump(bst, open(model_location, 'wb'), protocol=4)
+        with open(model_location, 'wb') as f:
+            pkl.dump(bst, f, protocol=4)
         logging.debug("Stored trained model at {}".format(model_location))

--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -237,5 +237,5 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, model_dir, checkpoint_dir, 
 
     if is_master:
         model_location = model_dir + '/xgboost-model'
-        pkl.dump(bst, open(model_location, 'wb'))
+        pkl.dump(bst, open(model_location, 'wb'), protocol=4)
         logging.debug("Stored trained model at {}".format(model_location))

--- a/src/sagemaker_xgboost_container/checkpointing.py
+++ b/src/sagemaker_xgboost_container/checkpointing.py
@@ -372,7 +372,7 @@ class SaveIntermediateModel(object):
         """Save intermediate model to intermediate model directory"""
         with tempfile.NamedTemporaryFile(
                 dir=self.intermediate_model_dir, delete=False) as tf:
-            pkl.dump(model, tf)
+            pkl.dump(model, tf, protocol=4)
 
         save_file_path = self.format_path()
         os.rename(tf.name, save_file_path)


### PR DESCRIPTION
Pickle protocol v3 does not support model sizes of 4GB or greater.

*Issue #, if available:* N/A

*Description of changes:* This change switches the pickle protocol version on write to use pickle protocol v4. Since the protocol version on load is [detected automatically](https://docs.python.org/3/library/pickle.html#pickle.load), the change should be backwards compatible and loading code does not need any changes. The purpose is to support writing of large models (>4GB).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
