### PR TITLE
[Bug fix] Use provided predict_fn in customer script

### DIFF
--- a/src/sagemaker_xgboost_container/serving.py
+++ b/src/sagemaker_xgboost_container/serving.py
@@ -114,7 +114,7 @@ def _user_module_transformer(user_module):
         return transformer.Transformer(
             model_fn=model_fn,
             input_fn=input_fn or default_input_fn,
-            predict_fn=default_predict_fn,
+            predict_fn=predict_fn or default_predict_fn,
             output_fn=output_fn or default_output_fn,
         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A bug fix. If `predict_fn` is provided in script mode, this should be passed to `Transformer`. Added unit tests to prevent future regression.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
