### PR TITLE
Use provided predict_fn in customer script (#136)

### DIFF
--- a/src/sagemaker_xgboost_container/serving.py
+++ b/src/sagemaker_xgboost_container/serving.py
@@ -114,7 +114,7 @@ def _user_module_transformer(user_module):
         return transformer.Transformer(
             model_fn=model_fn,
             input_fn=input_fn or default_input_fn,
-            predict_fn=default_predict_fn,
+            predict_fn=predict_fn or default_predict_fn,
             output_fn=output_fn or default_output_fn,
         )
 


### PR DESCRIPTION
*Description of changes:*

Same changes as #136. This CR is a cherry-picked commit https://github.com/aws/sagemaker-xgboost-container/commit/1fb22c712e374816e66ff5122b15ff19e9486178 against 1.0-1.

A bug fix. If predict_fn is provided in script mode, this should be passed to Transformer. Added unit tests to prevent future regression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
