### PR TITLE
Pin miniconda version to avoid breaking changes

### DIFF
--- a/docker/1.0-1/base/Dockerfile.cpu
+++ b/docker/1.0-1/base/Dockerfile.cpu
@@ -18,9 +18,10 @@ RUN apt-get -y install openjdk-8-jdk-headless
 
 # Install mlio
 RUN echo 'installing miniconda' && \
-    curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3 && \
-    rm Miniconda3-latest-Linux-x86_64.sh
+    curl -LO https://repo.anaconda.com/miniconda/Miniconda3-py38_4.8.3-Linux-x86_64.sh && \
+    echo "d63adf39f2c220950a063e0529d4ff74 Miniconda3-py38_4.8.3-Linux-x86_64.sh" | md5sum -c - && \
+    bash Miniconda3-py38_4.8.3-Linux-x86_64.sh -bfp /miniconda3 && \
+    rm Miniconda3-py38_4.8.3-Linux-x86_64.sh
 
 ENV PATH=/miniconda3/bin:${PATH}
 


### PR DESCRIPTION
*Description of changes:*

This PR pins miniconda version to avoid breaking changes. See a related PR https://github.com/aws/sagemaker-scikit-learn-container/pull/58 for an example where a rebuild of the image can bump the Python version.

https://github.com/aws/sagemaker-scikit-learn-container/pull/58 uses ARG variables for version numbers, but since the 1.0-1 branch is no longer in active development and we expect only security patches and bug fixes to go into this branch, I opted for not using ARG variables and making only minimal changes.

Looking at https://repo.anaconda.com/miniconda/, `Miniconda3-latest-Linux-x86_64.sh` was released on 2020-06-16 with checksum `d63adf39f2c220950a063e0529d4ff74`. Our last 1.0-1 deployment was on 2020-07-20. This corresponds to `Miniconda3-py38_4.8.3-Linux-x86_64.sh`.

The current prod image has Python 3.6. (The Python version is specified in [here](https://github.com/aws/sagemaker-xgboost-container/blob/1.0-1/docker/1.0-1/base/Dockerfile.cpu#L27).
```
$ docker run 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.0-1-cpu-py3 sh -c 'python --version'
Python 3.6.10 :: Anaconda, Inc.
```
The image built from this PR:
```
$ docker run preprod-xgboost-container:1.0-1-cpu-py3 sh -c 'python --version'
Python 3.6.10 :: Anaconda, Inc.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
