### PR TITLE
Pin conda installation file for 1.2-1

### DIFF
--- a/docker/1.2-1/base/Dockerfile.cpu
+++ b/docker/1.2-1/base/Dockerfile.cpu
@@ -3,6 +3,9 @@ ARG CUDA_VERSION=10.2
 
 FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu${UBUNTU_VERSION}
 
+ARG CONDA_VERSION=4.8.3
+ARG CONDA_PY_VERSION=38
+ARG CONDA_CHECKSUM="d63adf39f2c220950a063e0529d4ff74"
 ARG PYTHON_VERSION=3.7
 ARG PYARROW_VERSION=0.16.0
 ARG MLIO_VERSION=0.6.0
@@ -62,10 +65,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install conda
-RUN echo 'installing miniconda' && \
-    curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3 && \
-    rm Miniconda3-latest-Linux-x86_64.sh
+RUN cd /tmp && \
+    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-py${CONDA_PY_VERSION}_${CONDA_VERSION}-Linux-x86_64.sh && \
+    echo "${CONDA_CHECKSUM} /tmp/Miniconda3.sh" | md5sum -c - && \
+    bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
+    rm /tmp/Miniconda3.sh
 
 ENV PATH=/miniconda3/bin:${PATH}
 

--- a/docker/1.2-1/final/Dockerfile.cpu
+++ b/docker/1.2-1/final/Dockerfile.cpu
@@ -15,7 +15,7 @@ RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 # Copy wheel to container #
 ###########################
 COPY dist/sagemaker_xgboost_container-2.0-py2.py3-none-any.whl /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
-RUN pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
+RUN python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
     rm /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
 
 ##############

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,20 @@
+Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML<4.3
+boto3==1.14.62
+botocore==1.17.62
 gunicorn<20.0.0
-matplotlib
+matplotlib==3.3.2
 multi-model-server==1.1.1
-numpy==1.19.1
-pandas>=0.24.0
+numpy==1.19.2
+pandas==1.1.3
 psutil==5.6.7  # sagemaker-containers requires psutil 5.6.7
 python-dateutil==2.8.0
 requests<2.21
 retrying==1.3.3
+sagemaker-containers>=2.8.3,<2.9
 sagemaker-inference==1.2.0
-sagemaker-containers>=2.8.3
 scikit-learn==0.23.2
-scipy==1.5.2
+scipy==1.5.3
 smdebug==0.9.2
 urllib3<1.25
 wheel

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,4 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
-PyYAML<4.3
-boto3>=1.4.8
 coverage
 docker-compose
 flake8
@@ -8,8 +6,6 @@ mock
 pytest
 pytest-cov
 pytest-xdist
-python-dateutil==2.8.0
 sagemaker>=1.3.0,<2.0
-smdebug==0.9.2
 tox
 tox-conda


### PR DESCRIPTION
*Description of changes:*

Pins Python version in Conda. Without pinning the Python version, a rebuild of the image will bump the Python version when conda-latest bumps the Python version.

Also pins versions for all major dependencies. We have had too many issues related to Conda/Python/libraries getting upgraded inadvertently when a CodeBuild build is triggered. This PR pins the versions in `requirements.txt` to a specific version or puts an upper bound.

Duplicate entries in `test-requirements.txt` are removed because it is unnecessary have the libraries listed in  `requirements.txt` again in `test-requirements.txt`.

The versions were inspected with `pip freeze`:
```
docker run 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:0.90-2-cpu-py3 sh -c 'python -m pip freeze'
```

See also https://github.com/aws/sagemaker-xgboost-container/pull/139.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
