### PR TITLE
Pin conda installation file for 0.90-1

### DIFF
--- a/docker/0.90-1/base/Dockerfile.cpu
+++ b/docker/0.90-1/base/Dockerfile.cpu
@@ -12,14 +12,18 @@ RUN cd /tmp && \
      rm get-pip.py
 
 # Install mlio
-RUN echo 'installing miniconda'
-RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-RUN bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3
-RUN rm Miniconda3-latest-Linux-x86_64.sh
+RUN echo 'installing miniconda' && \
+    curl -LO http://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh && \
+    echo "81c773ff87af5cfac79ab862942ab6b3 Miniconda3-4.7.12.1-Linux-x86_64.sh" | md5sum -c - && \
+    bash Miniconda3-4.7.12.1-Linux-x86_64.sh -bfp /miniconda3 && \
+    rm Miniconda3-4.7.12.1-Linux-x86_64.sh
+
 ENV PATH=/miniconda3/bin:${PATH}
-RUN conda update -y conda
-RUN conda install -c conda-forge pyarrow=0.14.1
-RUN conda install -c mlio -c conda-forge mlio-py=0.1
+
+RUN conda install python=3.7 && \
+    conda update -y conda && \
+    conda install -c conda-forge pyarrow=0.14.1 && \
+    conda install -c mlio -c conda-forge mlio-py=0.1
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,17 @@
+Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML<4.3
+boto3==1.10.47
+botocore==1.13.47
 gunicorn<20.0.0
-matplotlib
-numpy
-pandas>=0.24.0
+matplotlib==3.1.2
+numpy==1.18.1
+pandas==0.25.3
 psutil==5.4.8  # sagemaker-containers requires psutil 5.4.8
 python-dateutil<2.8.1
 requests<2.21
 retrying==1.3.3
-sagemaker-containers>=2.5.6
-scikit-learn
-scipy
+sagemaker-containers==2.6.2
+scikit-learn==0.22.1
+scipy==1.2.2
 urllib3<1.25
 wheel

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
-Flask
+Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML<4.3
-boto3>=1.4.8
+boto3==1.10.47
 coverage
 docker-compose
 flake8
@@ -8,6 +8,6 @@ mock
 pytest
 pytest-cov
 pytest-xdist
-sagemaker>=1.3.0
+sagemaker>=1.3.0,<2.0
 tox
 tox-conda


### PR DESCRIPTION
*Description of changes:*

Pins Python version in Conda for 0.90-1. Without pinning the Python version, a rebuild of the image will bump the Python version when conda-latest bumps the Python version.

See also https://github.com/aws/sagemaker-xgboost-container/pull/139 and https://github.com/aws/sagemaker-xgboost-container/pull/140.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
