### PR TITLE
Pin dependency versions for 1.0-1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,19 @@
+Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML<4.3
+boto3==1.10.14
+botocore==1.13.14
 gunicorn<20.0.0
-matplotlib
+matplotlib==3.3.2
 multi-model-server==1.1.1
-numpy
-pandas>=0.24.0
+numpy==1.19.2
+pandas==1.1.3
 psutil==5.6.7  # sagemaker-containers requires psutil 5.6.7
 python-dateutil==2.8.0
 requests<2.21
 retrying==1.3.3
+sagemaker-containers>=2.8.3,<2.9
 sagemaker-inference==1.2.0
-sagemaker-containers>=2.8.3
-scikit-learn
+scikit-learn==0.23.2
 scipy==1.2.2
 smdebug==0.4.13
 urllib3<1.25

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,3 @@
-Flask
-PyYAML<4.3
-boto3>=1.4.8
 coverage
 docker-compose
 flake8
@@ -8,8 +5,6 @@ mock
 pytest
 pytest-cov
 pytest-xdist
-python-dateutil==2.8.0
-sagemaker>=1.3.0
-smdebug==0.4.13
+sagemaker>=1.3.0,<2.0
 tox
 tox-conda


### PR DESCRIPTION
*Description of changes:*

Pins versions for all major dependencies. We have had too many issues related to Conda/Python/libraries getting upgraded inadvertently when a CodeBuild build is triggered. This PR pins the versions in `requirements.txt` to a specific version or puts an upper bound.

The versions were inspected with `pip freeze`:
```
docker run 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.0-1-cpu-py3 sh -c 'python -m pip freeze'
```

See also https://github.com/aws/sagemaker-xgboost-container/pull/140.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
