### PR TITLE
Pin miniconda python version to 3.7

### DIFF
--- a/docker/0.90-1/base/Dockerfile.cpu
+++ b/docker/0.90-1/base/Dockerfile.cpu
@@ -1,25 +1,29 @@
-FROM ubuntu:16.04
+ARG UBUNTU_VERSION=16.04
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG CONDA_VERSION=4.7.12.1
+ARG CONDA_CHECKSUM="81c773ff87af5cfac79ab862942ab6b3"
+ARG PYTHON_VERSION=3.7
+ARG PYARROW_VERSION=0.14.1
+ARG MLIO_VERSION=0.1
 
 # Install python and other runtime dependencies
 RUN apt-get update && \
-    apt-get -y install build-essential libatlas-dev git wget curl nginx jq && \
-    apt-get -y install python3-dev python3-setuptools
+    apt-get -y install build-essential libatlas-dev git wget curl nginx jq
 
-# Install pip
-RUN cd /tmp && \
-     curl -O https://bootstrap.pypa.io/get-pip.py && \
-     python3 get-pip.py && \
-     rm get-pip.py
-
-# Install mlio
+# Install miniconda
 RUN echo 'installing miniconda'
-RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-RUN bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3
-RUN rm Miniconda3-latest-Linux-x86_64.sh
+RUN cd /tmp && \
+    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh && \
+    echo "${CONDA_CHECKSUM} /tmp/Miniconda3.sh" | md5sum -c - && \
+    bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
+    rm /tmp/Miniconda3.sh
 ENV PATH=/miniconda3/bin:${PATH}
-RUN conda update -y conda
-RUN conda install -c conda-forge pyarrow=0.14.1
-RUN conda install -c mlio -c conda-forge mlio-py=0.1
+RUN conda install python=${PYTHON_VERSION} && \
+    conda update -y conda && \
+    conda install -c conda-forge pyarrow=${PYARROW_VERSION} && \
+    conda install -c mlio -c conda-forge mlio-py=${MLIO_VERSION}
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging


### PR DESCRIPTION
*Description of changes:*
* Pin miniconda python version to 3.7 (change based on corresponding commit for sklearn: https://github.com/aws/sagemaker-scikit-learn-container/commit/95e7bdd9e4e62172cda0a4eca15dd8c06ccddaa2

*Testing:*
Test image built successfully and integration tests run against it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
