### PR TITLE
Pin conda and package dependencies for 0.90-2

### DIFF
--- a/docker/0.90-2/base/Dockerfile.cpu
+++ b/docker/0.90-2/base/Dockerfile.cpu
@@ -17,9 +17,10 @@ RUN apt-get -y install openjdk-8-jdk-headless
 
 # Install mlio
 RUN echo 'installing miniconda' && \
-    curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3 && \
-    rm Miniconda3-latest-Linux-x86_64.sh
+    curl -LO https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh && \
+    echo "87e77f097f6ebb5127c77662dfc3165e Miniconda3-py37_4.8.2-Linux-x86_64.sh" | md5sum -c - && \
+    bash Miniconda3-py37_4.8.2-Linux-x86_64.sh -bfp /miniconda3 && \
+    rm Miniconda3-py37_4.8.2-Linux-x86_64.sh
 
 ENV PATH=/miniconda3/bin:${PATH}
 
@@ -35,4 +36,4 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING='utf-8'
 
 # Install latest version of XGBoost
-RUN pip install --no-cache -I xgboost==0.90
+RUN python3 -m pip install --no-cache -I xgboost==0.90

--- a/docker/0.90-2/final/Dockerfile.cpu
+++ b/docker/0.90-2/final/Dockerfile.cpu
@@ -11,7 +11,9 @@ RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 # Copy wheel to container #
 ###########################
 COPY dist/sagemaker_xgboost_container-2.0-py2.py3-none-any.whl /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
-RUN python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
+# https://github.com/googleapis/google-cloud-python/issues/6647
+RUN rm -rf /miniconda3/lib/python3.6/site-packages/numpy-1.19.4.dist-info && \
+    python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
     rm /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
 
 ##############

--- a/docker/0.90-2/final/Dockerfile.cpu
+++ b/docker/0.90-2/final/Dockerfile.cpu
@@ -5,13 +5,13 @@ ENV SAGEMAKER_XGBOOST_VERSION 0.90-2
 # Install dependencies #
 ########################
 COPY requirements.txt /requirements.txt
-RUN pip install -r /requirements.txt && rm /requirements.txt
+RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 
 ###########################
 # Copy wheel to container #
 ###########################
 COPY dist/sagemaker_xgboost_container-2.0-py2.py3-none-any.whl /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
-RUN pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
+RUN python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
     rm /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
 
 ##############

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,19 @@
+Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML<4.3
+boto3==1.13.21
+botocore==1.13.14
 gunicorn<20.0.0
-matplotlib
+matplotlib==3.2.1
 multi-model-server==1.1.1
-numpy
-pandas>=0.24.0
+numpy==1.18.4
+pandas==1.0.4
 psutil==5.6.7  # sagemaker-containers requires psutil 5.6.7
 python-dateutil==2.8.0
 requests<2.21
 retrying==1.3.3
-sagemaker-containers>=2.8.3
+sagemaker-containers>=2.8.3,<2.9
 sagemaker-inference==1.2.0
-scikit-learn
+scikit-learn==0.23.1
 scipy==1.2.2
 smdebug==0.4.13
 urllib3<1.25

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,3 @@
-Flask
-PyYAML<4.3
-boto3>=1.4.8
 coverage
 docker-compose
 flake8
@@ -8,8 +5,6 @@ mock
 pytest
 pytest-cov
 pytest-xdist
-python-dateutil==2.8.0
-sagemaker>=1.3.0
-smdebug==0.4.13
+sagemaker>=1.3.0,<2.0
 tox
 tox-conda


### PR DESCRIPTION
*Description of changes:*

Pins Python version in Conda for 0.90-2. Without pinning the Python version, a rebuild of the image will bump the Python version when conda-latest bumps the Python version.

The versions in `requirements.txt` were changed to match the versions in the output of `python3 -m pip freeze` of the current prod image `0.90-2-cpu-py3`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
