### PR TITLE
Pin conda and package dependencies for 0.90-1

### DIFF
--- a/docker/0.90-1/base/Dockerfile.cpu
+++ b/docker/0.90-1/base/Dockerfile.cpu
@@ -31,4 +31,4 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING='utf-8'
 
 # Install latest version of XGBoost
-RUN pip install --no-cache -I xgboost==0.90
+RUN python3 -m pip install --no-cache -I xgboost==0.90

--- a/docker/0.90-1/final/Dockerfile.cpu
+++ b/docker/0.90-1/final/Dockerfile.cpu
@@ -18,12 +18,14 @@ ENV SAGEMAKER_SERVING_MODULE sagemaker_xgboost_container.serving:main
 ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.5/dist-packages/xgboost/dmlc-core/tracker
 
 COPY requirements.txt /requirements.txt
-RUN pip install -r /requirements.txt && rm /requirements.txt
+RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 
 # DMLC patches; TODO: remove after making contributions back to xgboost for tracker.py
 COPY src/sagemaker_xgboost_container/dmlc_patch/tracker.py \
    /usr/local/lib/python3.5/dist-packages/xgboost/dmlc-core/tracker/dmlc_tracker/tracker.py
 
 COPY dist/sagemaker_xgboost_container-1.0-py2.py3-none-any.whl /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
-RUN pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
+# https://github.com/googleapis/google-cloud-python/issues/6647
+RUN rm -rf /miniconda3/lib/python3.7/site-packages/numpy-1.19.4.dist-info && \
+    python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
     rm /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,17 @@
+Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML<4.3
+boto3==1.10.47
+botocore==1.13.47
 gunicorn<20.0.0
-matplotlib
-numpy
-pandas>=0.24.0
+matplotlib==3.1.2
+numpy==1.18.1
+pandas==0.25.3
 psutil==5.4.8  # sagemaker-containers requires psutil 5.4.8
 python-dateutil<2.8.1
 requests<2.21
 retrying==1.3.3
-sagemaker-containers>=2.5.6
-scikit-learn
-scipy
+sagemaker-containers==2.6.2
+scikit-learn==0.22.1
+scipy==1.2.2
 urllib3<1.25
 wheel

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
-Flask
 PyYAML<4.3
-boto3>=1.4.8
+boto3==1.10.47
 coverage
 docker-compose
 flake8
@@ -8,6 +7,6 @@ mock
 pytest
 pytest-cov
 pytest-xdist
-sagemaker>=1.3.0
+sagemaker>=1.3.0,<2.0
 tox
 tox-conda


### PR DESCRIPTION
*Description of changes:*

Pins Python version in Conda for 0.90-1. Without pinning the Python version, a rebuild of the image will bump the Python version when conda-latest bumps the Python version.

The versions in `requirements.txt` were changed to match the versions in the output of `python3 -m pip freeze` of the current prod image `0.90-1-cpu-py3`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
