### PR TITLE
Pin versions and add container test for verifying installed versions

### DIFF
--- a/docker/1.2-1/base/Dockerfile.cpu
+++ b/docker/1.2-1/base/Dockerfile.cpu
@@ -1,11 +1,13 @@
 ARG UBUNTU_VERSION=18.04
 ARG CUDA_VERSION=10.2
+ARG IMAGE_DIGEST=1774efa6e102a9bdfa393521c6b2254ea751dc1af9cff25c51376128bfb08d5e
 
-FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu${UBUNTU_VERSION}
+FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu${UBUNTU_VERSION}@sha256:${IMAGE_DIGEST}
 
-ARG CONDA_VERSION=4.8.3
+ARG MINICONDA_VERSION=4.8.3
 ARG CONDA_PY_VERSION=38
 ARG CONDA_CHECKSUM="d63adf39f2c220950a063e0529d4ff74"
+ARG CONDA_PKG_VERSION=4.9.0
 ARG PYTHON_VERSION=3.7
 ARG PYARROW_VERSION=0.16.0
 ARG MLIO_VERSION=0.6.0
@@ -51,7 +53,8 @@ RUN apt-get update && \
         autoconf \
         automake \
         build-essential \
-        cmake \
+        cmake=3.18.4-0kitware1 \
+        cmake-data=3.18.4-0kitware1 \
         doxygen \
         libcurl4-openssl-dev \
         libssl-dev \
@@ -66,7 +69,7 @@ RUN apt-get update && \
 
 # Install conda
 RUN cd /tmp && \
-    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-py${CONDA_PY_VERSION}_${CONDA_VERSION}-Linux-x86_64.sh && \
+    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-py${CONDA_PY_VERSION}_${MINICONDA_VERSION}-Linux-x86_64.sh && \
     echo "${CONDA_CHECKSUM} /tmp/Miniconda3.sh" | md5sum -c - && \
     bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
     rm /tmp/Miniconda3.sh
@@ -76,7 +79,14 @@ ENV PATH=/miniconda3/bin:${PATH}
 # Install MLIO with Apache Arrow integration
 # We could install mlio-py from conda, but it comes  with extra support such as image reader that increases image size
 # which increases training time. We build from source to minimize the image size.
-RUN conda install python=${PYTHON_VERSION} && \
+RUN echo "conda ${CONDA_PKG_VERSION}" >> /miniconda3/conda-meta/pinned && \
+    # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
+    conda config --system --set auto_update_conda false && \
+    conda config --system --set show_channel_urls true && \
+    echo "python ${PYTHON_VERSION}.*" >> /miniconda3/conda-meta/pinned && \
+    conda install python=${PYTHON_VERSION} && \
+    conda install python=${PYTHON_VERSION} && \
+    conda install conda=${CONDA_PKG_VERSION} && \
     conda update -y conda && \
     conda install -c conda-forge pyarrow=${PYARROW_VERSION} && \
     cd /tmp && \

--- a/docker/1.2-1/final/Dockerfile.cpu
+++ b/docker/1.2-1/final/Dockerfile.cpu
@@ -15,7 +15,8 @@ RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 # Copy wheel to container #
 ###########################
 COPY dist/sagemaker_xgboost_container-2.0-py2.py3-none-any.whl /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
-RUN python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
+RUN rm -rf /miniconda3/lib/python3.7/site-packages/numpy-1.19.4.dist-info && \
+    python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
     rm /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
 
 ##############

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
-PyYAML<4.3
+PyYAML==3.13
 boto3==1.14.62
 botocore==1.17.62
-gunicorn<20.0.0
+gunicorn==19.10.0
 matplotlib==3.3.2
 multi-model-server==1.1.1
 numpy==1.19.2
 pandas==1.1.3
 psutil==5.6.7  # sagemaker-containers requires psutil 5.6.7
 python-dateutil==2.8.0
-requests<2.21
+requests==2.20.1
 retrying==1.3.3
-sagemaker-containers>=2.8.3,<2.9
+sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.2.0
 scikit-learn==0.23.2
 scipy==1.5.3
 smdebug==0.9.2
-urllib3<1.25
-wheel
+urllib3==1.24.3
+wheel==0.35.1

--- a/test/integration/local/test_versions.py
+++ b/test/integration/local/test_versions.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import os
+
+from test.utils import local_mode
+
+
+path = os.path.dirname(os.path.realpath(__file__))
+script_path = os.path.join(path, "..", "..", "resources", "versions")
+abalone_path = os.path.join(path, "..", "..", "resources", "abalone")
+data_dir = os.path.join(abalone_path, "data")
+
+
+def test_package_version(docker_image, opt_ml):
+    version_check_script = "train.py"
+
+    local_mode.train(
+        version_check_script,
+        data_dir,
+        docker_image,
+        opt_ml,
+        source_dir=script_path,
+    )
+
+    assert not local_mode.file_exists(opt_ml, "output/failure"), "Failure happened"

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -1,0 +1,53 @@
+import pkg_resources
+import sys
+
+
+PYTHON_MAJOR_VERSION = 3
+PYTHON_MINOR_VERSION = 7
+REQUIREMENTS = """\
+Flask==1.1.1
+PyYAML==3.13
+boto3==1.14.62
+botocore==1.17.62
+conda==4.9.0
+gunicorn==19.10.0
+matplotlib==3.3.2
+multi-model-server==1.1.1
+numpy==1.19.2
+pandas==1.1.3
+psutil==5.6.7
+pyarrow==0.16.0
+python-dateutil==2.8.0
+requests==2.20.1
+retrying==1.3.3
+sagemaker-containers==2.8.6.post2
+sagemaker-inference==1.2.0
+scikit-learn==0.23.2
+scipy==1.5.3
+smdebug==0.9.2
+urllib3==1.24.3
+wheel==0.35.1
+
+""".strip()
+
+
+def assert_python_version(major, minor):
+    assert sys.version_info.major == major and sys.version_info.minor == minor
+
+
+def assert_package_version(package_name, version):
+    installed_version = pkg_resources.get_distribution(package_name).version
+    error_message = f"{package_name} requires {version} but {installed_version} is installed."
+    assert version == installed_version, error_message
+
+
+def parse_requirements(requirements):
+    for package_equals_version in requirements.split('\n'):
+        package, version = package_equals_version.split("==")
+        yield package, version
+
+
+if __name__ == '__main__':
+    assert_python_version(PYTHON_MAJOR_VERSION, PYTHON_MINOR_VERSION)
+    for package, version in parse_requirements(REQUIREMENTS):
+        assert_package_version(package, version)


### PR DESCRIPTION
*Description of changes:*

- Pins "cmake" version because [AWS SDK doesn't build with the latest version of cmake](https://github.com/aws/aws-sdk-cpp/issues/1537), which also breaks MLIO bulid.
- Pins the base image SHA. SHA is taken from the latest build that was deployed to prod.
- Pins the Conda package version. (There's the Miniconda version for installation, and inside Miniconda the "conda" package can be updated unknowingly if the version is not pinned.)
- Pins package versions in requirements.txt. The versions are chosen to match the package versions in the current prod image.

Reference:
https://github.com/aws/sagemaker-scikit-learn-container/pull/64

*Testing*
`tox`
`pytest test/integration/local -k 'versions' --docker-base-name preprod-xgboost-container --tag 1.2-1-cpu-py3 --py-version 3 --framework-version 1.2-1`
integration tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
