### PR TITLE
Bump Python to 3.7.10

### DIFF
--- a/docker/1.2-1/base/Dockerfile.cpu
+++ b/docker/1.2-1/base/Dockerfile.cpu
@@ -8,7 +8,7 @@ ARG MINICONDA_VERSION=4.8.3
 ARG CONDA_PY_VERSION=38
 ARG CONDA_CHECKSUM="d63adf39f2c220950a063e0529d4ff74"
 ARG CONDA_PKG_VERSION=4.9.0
-ARG PYTHON_VERSION=3.7
+ARG PYTHON_VERSION=3.7.10
 ARG PYARROW_VERSION=0.16.0
 ARG MLIO_VERSION=0.6.0
 ARG XGBOOST_VERSION=1.2.0
@@ -84,8 +84,7 @@ RUN echo "conda ${CONDA_PKG_VERSION}" >> /miniconda3/conda-meta/pinned && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
     echo "python ${PYTHON_VERSION}.*" >> /miniconda3/conda-meta/pinned && \
-    conda install python=${PYTHON_VERSION} && \
-    conda install python=${PYTHON_VERSION} && \
+    conda install -c conda-forge python=${PYTHON_VERSION} && \
     conda install conda=${CONDA_PKG_VERSION} && \
     conda update -y conda && \
     conda install -c conda-forge pyarrow=${PYARROW_VERSION} && \


### PR DESCRIPTION
*Description of changes:*

Bump Python to 3.7.10 for the following security vulnerability:
- [CVE-2021-3177](https://nvd.nist.gov/vuln/detail/CVE-2021-3177)

Python 3.7.10 became available in `conda-forge`: https://github.com/conda-forge/python-feedstock/pull/452

```
root@876fd2ced4cc:/# python -c  "import sys; from ctypes import *; \
  print('Testing ' + sys.executable); \
  print(sys.version_info); \
  print(c_double.from_param(1e300)); \
  print('If this is printed, you are patched')"
Testing /miniconda3/bin/python
sys.version_info(major=3, minor=7, micro=10, releaselevel='final', serial=0)
<cparam 'd' (1e+300)>
If this is printed, you are patched
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
