### PR TITLE
Bump Python to 3.7.10

### DIFF
--- a/docker/0.90-1/base/Dockerfile.cpu
+++ b/docker/0.90-1/base/Dockerfile.cpu
@@ -4,7 +4,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 
 ARG CONDA_VERSION=4.7.12.1
 ARG CONDA_CHECKSUM="81c773ff87af5cfac79ab862942ab6b3"
-ARG PYTHON_VERSION=3.7
+ARG PYTHON_VERSION=3.7.10
 ARG PYARROW_VERSION=0.14.1
 ARG MLIO_VERSION=0.1
 
@@ -20,8 +20,9 @@ RUN cd /tmp && \
     bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
     rm /tmp/Miniconda3.sh
 ENV PATH=/miniconda3/bin:${PATH}
-RUN conda install python=${PYTHON_VERSION} && \
+RUN conda install -c conda-forge python=${PYTHON_VERSION} && \
     conda update -y conda && \
+    conda install pip=20.1 && \
     conda install -c conda-forge pyarrow=${PYARROW_VERSION} && \
     conda install -c mlio -c conda-forge mlio-py=${MLIO_VERSION}
 

--- a/docker/0.90-1/final/Dockerfile.cpu
+++ b/docker/0.90-1/final/Dockerfile.cpu
@@ -15,14 +15,14 @@ ENV SAGEMAKER_TRAINING_MODULE sagemaker_xgboost_container.training:main
 ENV SAGEMAKER_SERVING_MODULE sagemaker_xgboost_container.serving:main
 
 # Include DMLC python code in PYTHONPATH to use RabitTracker
-ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.5/dist-packages/xgboost/dmlc-core/tracker
+ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.7/dist-packages/xgboost/dmlc-core/tracker
 
 COPY requirements.txt /requirements.txt
 RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 
 # DMLC patches; TODO: remove after making contributions back to xgboost for tracker.py
 COPY src/sagemaker_xgboost_container/dmlc_patch/tracker.py \
-   /usr/local/lib/python3.5/dist-packages/xgboost/dmlc-core/tracker/dmlc_tracker/tracker.py
+   /usr/local/lib/python3.7/dist-packages/xgboost/dmlc-core/tracker/dmlc_tracker/tracker.py
 
 COPY dist/sagemaker_xgboost_container-1.0-py2.py3-none-any.whl /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
 # https://github.com/googleapis/google-cloud-python/issues/6647

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py3}-xgboost{0.90},flake8
+envlist = {py37}-xgboost{0.90},flake8
 
 [flake8]
 max-line-length = 120
@@ -21,6 +21,7 @@ conda_channels=
     mlio
 commands =
     pytest --cov=sagemaker_xgboost_container --cov-fail-under=60 test/unit # increase minimum bar over time (75%+)
+install_command = python3 -m pip install {opts} {packages} --use-deprecated=legacy-resolver
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
*Description of changes:*

This PR is for the 0.90-1 branch.

1. Bump Python to 3.7.10 to fix the following security vulnerability. Python 3.6 was upgraded to 3.7.10 in `conda-forge`: https://github.com/conda-forge/python-feedstock/pull/452.
    - [CVE-2021-3177](https://nvd.nist.gov/vuln/detail/CVE-2021-3177)
2. The [new pip dependency resolver](https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies) in pip v.20.2+ can't resolve the dependencies in the 1.0-1, 0.90-2, and 0.90-1 branches. (1.2-1 works with v20.2+). This PR also pins the pip version to 20.1 and chooses the old resolver behavior using the flag `--use-deprecated=legacy-resolver`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
