### PR TITLE
Bump Python to 3.6.13

### DIFF
--- a/docker/0.90-2/base/Dockerfile.cpu
+++ b/docker/0.90-2/base/Dockerfile.cpu
@@ -24,8 +24,9 @@ RUN echo 'installing miniconda' && \
 
 ENV PATH=/miniconda3/bin:${PATH}
 
-RUN conda install python=3.6 && \
+RUN conda install -c conda-forge python=3.6.13 && \
     conda update -y conda && \
+    conda install pip=20.1 && \
     conda install -c conda-forge pyarrow=0.14.1 && \
     conda install -c mlio -c conda-forge mlio-py=0.1
 

--- a/docker/0.90-2/final/Dockerfile.cpu
+++ b/docker/0.90-2/final/Dockerfile.cpu
@@ -12,7 +12,7 @@ RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 ###########################
 COPY dist/sagemaker_xgboost_container-2.0-py2.py3-none-any.whl /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
 # https://github.com/googleapis/google-cloud-python/issues/6647
-RUN rm -rf /miniconda3/lib/python3.6/site-packages/numpy-1.19.4.dist-info && \
+RUN rm -rf /miniconda3/lib/python3.6/site-packages/numpy-1.19.5.dist-info && \
     python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
     rm /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py3}-xgboost{0.90},flake8
+envlist = {py36}-xgboost{0.90},flake8
 
 [flake8]
 max-line-length = 120
@@ -21,6 +21,7 @@ conda_channels=
     mlio
 commands =
     pytest --cov=sagemaker_xgboost_container --cov-fail-under=60 test/unit # increase minimum bar over time (75%+)
+install_command = python3 -m pip install {opts} {packages} --use-deprecated=legacy-resolver
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
*Description of changes:*

This PR is for the 0.90-2 branch.

1. Bump Python to 3.6.13 to fix the following security vulnerability. Python 3.6 was upgraded to 3.6.13 in `conda-forge`: https://github.com/conda-forge/python-feedstock/pull/451.
    - [CVE-2021-3177](https://nvd.nist.gov/vuln/detail/CVE-2021-3177)
2. The [new pip dependency resolver](https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies) in pip v.20.2+ can't resolve the dependencies in the 1.0-1, 0.90-2, and 0.90-1 branches. (1.2-1 works with v20.2+). This PR also pins the pip version to 20.1 and chooses the old resolver behavior using the flag `--use-deprecated=legacy-resolver`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
