### PR TITLE
fix custom metrics for 1.2

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -228,7 +228,7 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
     add_debugging(callbacks=callbacks, hyperparameters=train_cfg, train_dmatrix=train_dmatrix,
                   val_dmatrix=val_dmatrix)
 
-    logging.info("Train matrix has {} rows".format(train_dmatrix.num_row()))
+    logging.info("Train matrix has {} rows and {} columns".format(train_dmatrix.num_row(), train_dmatrix.num_col()))
     if val_dmatrix:
         logging.info("Validation matrix has {} rows".format(val_dmatrix.num_row()))
 
@@ -240,12 +240,12 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
                         verbose_eval=False)
 
         if nfold is not None and train_val_dmatrix is not None:
-            logging.info("Run {} fold cross validation on the data of {} rows".format(nfold,
+            logging.info("Run {}-fold cross validation on the data of {} rows".format(nfold,
                                                                                       train_val_dmatrix.num_row()))
             # xgb.cv returns a pandas data frame of evaluation results.
             cv_eval_result = xgb.cv(train_cfg, train_val_dmatrix, nfold=nfold, num_boost_round=num_round,
                                     feval=configured_feval, early_stopping_rounds=early_stopping_rounds,
-                                    show_stdv=True, verbose_eval=True)
+                                    verbose_eval=True, show_stdv=True, shuffle=False)
 
             logging.info("Print the metrics of last epoch in the format expected by HPO")
             cv_last_epoch = len(cv_eval_result.index) - 1

--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -247,7 +247,7 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
                                     feval=configured_feval, early_stopping_rounds=early_stopping_rounds,
                                     verbose_eval=True, show_stdv=True, shuffle=False)
 
-            logging.info("Print the metrics of last epoch in the format expected by HPO")
+            logging.info("The final metrics of cross validation")
             cv_last_epoch = len(cv_eval_result.index) - 1
             cv_eval_report = f"[{cv_last_epoch}]"
             cv_eval_columns = cv_eval_result.columns

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import numpy as np
-from math import exp
 from sklearn.metrics import accuracy_score, f1_score, mean_squared_error
 
 
@@ -23,8 +22,9 @@ from sklearn.metrics import accuracy_score, f1_score, mean_squared_error
 # https://github.com/dmlc/xgboost/releases/tag/v1.2.0
 # https://discuss.xgboost.ai/t/output-margin-and-leaf-probabilities/798
 def sigmoid(x):
-    """Transform binary classification margin output to probability"""
-    return 1 / (1 + exp(-x))
+    """Transform binary classification margin output to probability
+    Instead of exp(-x), we employ tanh as it is stable, fast, and fairly accurate."""
+    return .5 * (1 + np.tanh(.5 * x))
 
 
 # TODO: Rename both according to AutoML standards

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -45,7 +45,6 @@ def accuracy(preds, dtrain):
     :return: Metric name, accuracy value.
     """
     labels = dtrain.get_label()
-    # pred_labels = [np.argmax(x) if (type(x) is np.ndarray) else round(sigmoid(x)) for x in preds]
     pred_labels = margin_to_class_label(preds)
     return 'accuracy', accuracy_score(labels, pred_labels)
 
@@ -60,7 +59,6 @@ def f1(preds, dtrain):
     :return: Metric name, f1 score
     """
     labels = dtrain.get_label()
-    # pred_labels = [np.argmax(x) if (type(x) is np.ndarray) else round(sigmoid(x)) for x in preds]
     pred_labels = margin_to_class_label(preds)
     return 'f1', f1_score(labels, pred_labels, average='macro')
 

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -31,7 +31,7 @@ def margin_to_class_label(preds):
     if type(preds[0]) is np.ndarray:
         return np.argmax(preds, axis=-1)
     else:
-        return (preds > 0).astype(int)
+        return (preds > 0.).astype(int)
 
 
 # TODO: Rename both according to AutoML standards
@@ -42,9 +42,12 @@ def accuracy(preds, dtrain):
     :param dtrain: Training data with labels
     :return: Metric name, accuracy value.
     """
-    labels = dtrain.get_label()
-    pred_labels = margin_to_class_label(preds)
-    return 'accuracy', accuracy_score(labels, pred_labels)
+    score = 0.0
+    if preds.size > 0:
+        labels = dtrain.get_label()
+        pred_labels = margin_to_class_label(preds)
+        score = accuracy_score(labels, pred_labels)
+    return 'accuracy', score
 
 
 def f1(preds, dtrain):
@@ -56,9 +59,12 @@ def f1(preds, dtrain):
     :param dtrain: Training data with labels
     :return: Metric name, f1 score
     """
-    labels = dtrain.get_label()
-    pred_labels = margin_to_class_label(preds)
-    return 'f1', f1_score(labels, pred_labels, average='macro')
+    score = 0.0
+    if preds.size > 0:
+        labels = dtrain.get_label()
+        pred_labels = margin_to_class_label(preds)
+        score = f1_score(labels, pred_labels, average='macro')
+    return 'f1', score
 
 
 def mse(preds, dtrain):

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -11,7 +11,20 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import numpy as np
+from math import exp
 from sklearn.metrics import accuracy_score, f1_score, mean_squared_error
+
+
+# From 1.2, custom evaluation metric receives raw prediction.
+# For binary classification (binary:logistic as objective),
+# the raw prediction is log-odds, which can be translated to
+# probability by sigmoid function. Note that the raw prediction
+# of XGBoost has to be added 0.5 before passing to sigmoid.
+# https://github.com/dmlc/xgboost/releases/tag/v1.2.0
+# https://discuss.xgboost.ai/t/output-margin-and-leaf-probabilities/798
+def sigmoid(x):
+    """Transform binary classification margin output to probability"""
+    return 1 / (1 + exp(-x))
 
 
 # TODO: Rename both according to AutoML standards
@@ -23,7 +36,7 @@ def accuracy(preds, dtrain):
     :return: Metric name, accuracy value.
     """
     labels = dtrain.get_label()
-    rounded_preds = [np.argmax(value) if (type(value) is np.ndarray) else round(value) for value in preds]
+    rounded_preds = [np.argmax(x) if (type(x) is np.ndarray) else round(sigmoid(x+0.5)) for x in preds]
     return 'accuracy', accuracy_score(labels, rounded_preds)
 
 
@@ -37,7 +50,7 @@ def f1(preds, dtrain):
     :return: Metric name, f1 score
     """
     labels = dtrain.get_label()
-    rounded_preds = [np.argmax(value) if (type(value) is np.ndarray) else round(value) for value in preds]
+    rounded_preds = [np.argmax(x) if (type(x) is np.ndarray) else round(sigmoid(x+0.5)) for x in preds]
     return 'f1', f1_score(labels, rounded_preds, average='macro')
 
 

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -19,8 +19,6 @@ from sklearn.metrics import accuracy_score, f1_score, mean_squared_error
 # the raw prediction is log-odds, which can be translated to
 # probability by sigmoid function.
 # https://github.com/dmlc/xgboost/releases/tag/v1.2.0
-
-
 def sigmoid(x):
     """Transform binary classification margin output to probability
     Instead of exp(-x), we employ tanh as it is stable, fast, and fairly accurate."""
@@ -28,8 +26,8 @@ def sigmoid(x):
 
 
 def margin_to_class_label(preds):
-    """Converts raw margin output to class label. Instead of coverting margin output to
-    probablity as intermediate step, we compare in logodds space (i.e. check if logodds > 0)."""
+    """Converts raw margin output to class label. Instead of converting margin output to
+    probability as intermediate step, we compare in log-odds space (i.e. check if log-odds > 0)."""
     if type(preds[0]) is np.ndarray:
         return np.argmax(preds, axis=-1)
     else:

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -86,3 +86,15 @@ def test_multiclass_f1_softprob():
     f1_score_name, f1_score_result = f1(multiclass_preds_softprob, multiclass_dtrain)
     assert f1_score_name == 'f1'
     assert f1_score_result == 1/15
+
+
+regression_train_data = np.random.rand(10, 2)
+regression_train_label = np.array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0])
+regression_dtrain = xgb.DMatrix(regression_train_data, label=regression_train_label)
+regression_preds = np.ones(10)
+
+
+def test_mse():
+    mse_score_name, mse_score_result = mse(regression_preds, regression_dtrain)
+    assert mse_score_name == 'mse'
+    assert mse_score_result == .5

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -20,7 +20,7 @@ binary_train_data = np.random.rand(10, 2)
 binary_train_label = np.array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0])
 binary_dtrain = xgb.DMatrix(binary_train_data, label=binary_train_label)
 # log(x/(1-x)) is the inverse function of sigmoid
-binary_preds = [log(0.7/0.3) - 0.5] * 10
+binary_preds = np.asarray([log(0.7/0.3) - 0.5] * 10)
 binary_preds_logistic = np.asarray([[log(0.1/0.9) - 0.5, log(0.9/0.1) - 0.5]] * 10)
 
 

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -12,15 +12,16 @@
 # language governing permissions and limitations under the License.
 import numpy as np
 import xgboost as xgb
-
+from math import log
 from sagemaker_xgboost_container.metrics.custom_metrics import accuracy, f1, mse
 
 
 binary_train_data = np.random.rand(10, 2)
 binary_train_label = np.array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0])
 binary_dtrain = xgb.DMatrix(binary_train_data, label=binary_train_label)
-binary_preds = np.ones(10)
-binary_preds_logistic = np.asarray([[0.1, 0.9]] * 10)
+# log(x/(1-x)) is the inverse function of sigmoid
+binary_preds = [log(0.7/0.3) - 0.5] * 10
+binary_preds_logistic = np.asarray([[log(0.1/0.9) - 0.5, log(0.9/0.1) - 0.5]] * 10)
 
 
 def test_binary_accuracy():
@@ -45,12 +46,6 @@ def test_binary_f1_logistic():
     f1_score_name, f1_score_result = f1(binary_preds_logistic, binary_dtrain)
     assert f1_score_name == 'f1'
     assert f1_score_result == 1/3
-
-
-def test_mse():
-    mse_score_name, mse_score_result = mse(binary_preds, binary_dtrain)
-    assert mse_score_name == 'mse'
-    assert mse_score_result == .5
 
 
 multiclass_train_data = np.random.rand(10, 2)


### PR DESCRIPTION
*Issue #, if available:*
AWSMLC-2746

*Description of changes:*
From 1.2, custom evaluation metric now receives raw prediction. This fixes the f1 and accuracy metrics with this breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
