### PR TITLE
add r2 score

### DIFF
--- a/src/sagemaker_xgboost_container/constants/xgb_constants.py
+++ b/src/sagemaker_xgboost_container/constants/xgb_constants.py
@@ -17,7 +17,8 @@ XGB_MAXIMIZE_METRICS = [
     'aucpr',
     'f1',
     'map',
-    'ndcg'
+    'ndcg',
+    'r2'
 ]
 
 XGB_MINIMIZE_METRICS = [

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import numpy as np
-from sklearn.metrics import accuracy_score, f1_score, mean_squared_error
+from sklearn.metrics import accuracy_score, f1_score, mean_squared_error, r2_score
 
 
 # From 1.2, custom evaluation metric receives raw prediction.
@@ -79,10 +79,23 @@ def mse(preds, dtrain):
     return 'mse', mean_squared_error(labels, preds)
 
 
+def r2(preds, dtrain):
+    """Compute R^2 (coefficient of determination) regression score.
+
+    For more information see: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html
+    :param preds: Prediction values
+    :param dtrain: Training data with labels
+    :return: Metric name, coefficient of determination
+    """
+    labels = dtrain.get_label()
+    return 'r2', r2_score(labels, preds)
+
+
 CUSTOM_METRICS = {
     "accuracy": accuracy,
     "f1": f1,
-    "mse": mse
+    "mse": mse,
+    "r2": r2
 }
 
 

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -13,7 +13,7 @@
 import numpy as np
 import xgboost as xgb
 from math import log
-from sagemaker_xgboost_container.metrics.custom_metrics import accuracy, f1, mse
+from sagemaker_xgboost_container.metrics.custom_metrics import accuracy, f1, mse, r2
 
 
 binary_train_data = np.random.rand(10, 2)
@@ -98,3 +98,9 @@ def test_mse():
     mse_score_name, mse_score_result = mse(regression_preds, regression_dtrain)
     assert mse_score_name == 'mse'
     assert mse_score_result == .5
+
+
+def test_r2():
+    r2_score_name, r2_score_result = r2(regression_preds, regression_dtrain)
+    assert r2_score_name == 'r2'
+    assert r2_score_result == -1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

R2 score is commonly used to evaluate regression quality. Add this metric as autopilot plans to use it as eval metric.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
