### PR TITLE
Bump Version Of Smdebug to 1.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.2.0
 scikit-learn==0.23.2
 scipy==1.5.3
-smdebug==1.0.2
+smdebug==1.0.7
 urllib3==1.25.9
 wheel==0.35.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This fixes the failure of the `LossNotDecreasing` Rule when run with 1-21 xgboost container.
- Details of the fix can be found on this PR. https://github.com/awslabs/sagemaker-debugger/pull/462 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
