### PR TITLE
Add f1_binary and f1_macro

### DIFF
--- a/src/sagemaker_xgboost_container/constants/xgb_constants.py
+++ b/src/sagemaker_xgboost_container/constants/xgb_constants.py
@@ -16,6 +16,8 @@ XGB_MAXIMIZE_METRICS = [
     'auc',
     'aucpr',
     'f1',
+    'f1_binary',
+    'f1_macro',
     'map',
     'ndcg',
     'r2'

--- a/src/sagemaker_xgboost_container/constants/xgb_constants.py
+++ b/src/sagemaker_xgboost_container/constants/xgb_constants.py
@@ -44,6 +44,7 @@ XGB_MINIMIZE_METRICS = [
 
 LOGISTIC_REGRESSION_LABEL_RANGE_ERROR = "label must be in [0,1] for logistic regression"
 MULTI_CLASS_LABEL_RANGE_ERROR = "label must be in [0, num_class)"
+MULTI_CLASS_F1_BINARY_ERROR = "Target is multiclass but average='binary'"
 FEATURE_MISMATCH_ERROR = "feature_names mismatch"
 LABEL_PREDICTION_SIZE_MISMATCH = "Check failed: preds.size() == info.labels_.size()"
 ONLY_POS_OR_NEG_SAMPLES = "Check failed: !auc_error AUC: the dataset only contains pos or neg samples"
@@ -56,6 +57,7 @@ REG_LAMBDA_ERROR = "Parameter reg_lambda should be greater equal to 0"
 CUSTOMER_ERRORS = [
     LOGISTIC_REGRESSION_LABEL_RANGE_ERROR,
     MULTI_CLASS_LABEL_RANGE_ERROR,
+    MULTI_CLASS_F1_BINARY_ERROR,
     FEATURE_MISMATCH_ERROR,
     LABEL_PREDICTION_SIZE_MISMATCH,
     ONLY_POS_OR_NEG_SAMPLES,

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -10,8 +10,6 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from collections import Counter
-
 import numpy as np
 from sklearn.metrics import accuracy_score, f1_score, mean_squared_error, r2_score
 

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -86,7 +86,7 @@ def f1_binary(preds, dtrain):
 
 
 def f1_macro(preds, dtrain):
-    """Compute f1 score. This can be used for multiclassification training.
+    """Compute f1 macro score. This can be used for multiclassification training.
 
     For more information see: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html
 

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -78,7 +78,6 @@ def f1_binary(preds, dtrain):
     if preds.size > 0:
         labels = dtrain.get_label()
         pred_labels = margin_to_class_label(preds)
-        # this function is used only for AutoPilot and the least frequent label is already encoded as 1.
         score = f1_score(labels, pred_labels, average='binary')
     return 'f1_binary', score
 

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -10,6 +10,8 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from collections import Counter
+
 import numpy as np
 from sklearn.metrics import accuracy_score, f1_score, mean_squared_error, r2_score
 
@@ -52,6 +54,39 @@ def accuracy(preds, dtrain):
 
 def f1(preds, dtrain):
     """Compute f1 score. This can be used for multiclassification training.
+    For more information see: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html
+    :param preds: Prediction values
+    :param dtrain: Training data with labels
+    :return: Metric name, f1 score
+    """
+    score = 0.0
+    if preds.size > 0:
+        labels = dtrain.get_label()
+        pred_labels = margin_to_class_label(preds)
+        score = f1_score(labels, pred_labels, average='macro')
+    return 'f1', score
+
+
+def f1_binary(preds, dtrain):
+    """Compute f1 binary score. This can be used for binaryclassification training.
+
+    For more information see: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html
+
+    :param preds: Prediction values
+    :param dtrain: Training data with labels
+    :return: Metric name, f1 score
+    """
+    score = 0.0
+    if preds.size > 0:
+        labels = dtrain.get_label()
+        pred_labels = margin_to_class_label(preds)
+        # this function is used only for AutoPilot and the least frequent label is already encoded as 1.
+        score = f1_score(labels, pred_labels, average='binary')
+    return 'f1_binary', score
+
+
+def f1_macro(preds, dtrain):
+    """Compute f1 score. This can be used for multiclassification training.
 
     For more information see: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html
 
@@ -64,7 +99,7 @@ def f1(preds, dtrain):
         labels = dtrain.get_label()
         pred_labels = margin_to_class_label(preds)
         score = f1_score(labels, pred_labels, average='macro')
-    return 'f1', score
+    return 'f1_macro', score
 
 
 def mse(preds, dtrain):
@@ -94,6 +129,8 @@ def r2(preds, dtrain):
 CUSTOM_METRICS = {
     "accuracy": accuracy,
     "f1": f1,
+    "f1_binary": f1_binary,
+    "f1_macro": f1_macro,
     "mse": mse,
     "r2": r2
 }

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -13,7 +13,7 @@
 import numpy as np
 import xgboost as xgb
 from math import log
-from sagemaker_xgboost_container.metrics.custom_metrics import accuracy, f1, mse, r2
+from sagemaker_xgboost_container.metrics.custom_metrics import accuracy, f1, mse, r2, f1_binary, f1_macro
 
 
 binary_train_data = np.random.rand(10, 2)
@@ -46,6 +46,18 @@ def test_binary_f1_logistic():
     f1_score_name, f1_score_result = f1(binary_preds_logistic, binary_dtrain)
     assert f1_score_name == 'f1'
     assert f1_score_result == 1/3
+
+
+def test_binary_f1_binary():
+    f1_score_name, f1_score_result = f1_binary(binary_preds, binary_dtrain)
+    assert f1_score_name == 'f1_binary'
+    assert f1_score_result == 2/3
+
+
+def test_binary_f1_binary_logistic():
+    f1_score_name, f1_score_result = f1_binary(binary_preds_logistic, binary_dtrain)
+    assert f1_score_name == 'f1_binary'
+    assert f1_score_result == 2/3
 
 
 multiclass_train_data = np.random.rand(10, 2)
@@ -85,6 +97,18 @@ def test_multiclass_f1():
 def test_multiclass_f1_softprob():
     f1_score_name, f1_score_result = f1(multiclass_preds_softprob, multiclass_dtrain)
     assert f1_score_name == 'f1'
+    assert f1_score_result == 1/15
+
+
+def test_multiclass_f1_macro():
+    f1_score_name, f1_score_result = f1_macro(multiclass_preds, multiclass_dtrain)
+    assert f1_score_name == 'f1_macro'
+    assert f1_score_result == 2/9
+
+
+def test_multiclass_f1_macro_softprob():
+    f1_score_name, f1_score_result = f1_macro(multiclass_preds_softprob, multiclass_dtrain)
+    assert f1_score_name == 'f1_macro'
     assert f1_score_result == 1/15
 
 


### PR DESCRIPTION
Change `f1` to `f1macro` to make it more explicit on what it does. `f1macro` should be used for multi-class classification datasets.
For binary classification tasks, use `f1` (with the average option 'binary').

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
