### PR TITLE
Install ubuntu security updates

### DIFF
--- a/docker/1.2-1/base/Dockerfile.cpu
+++ b/docker/1.2-1/base/Dockerfile.cpu
@@ -24,6 +24,7 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING='utf-8'
 
 RUN apt-get update && \
+    apt-get -y upgrade && \
     apt-get -y install --no-install-recommends \
         build-essential \
         curl \


### PR DESCRIPTION
*Description of changes:*

The latest image scan shows a high-level risk: [CVE-2021-3449](https://ubuntu.com/security/CVE-2021-3449). Running `apt-get upgrade` will install the latest security fixes.

Verified that the image built from this PR no longer has any high-level risks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
