### PR TITLE
Bump Pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4
-Pillow==8.1.1
+Pillow==8.2.0
 boto3==1.14.62
 botocore==1.17.62
 cryptography==3.4.6

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -6,7 +6,7 @@ PYTHON_MAJOR_VERSION = 3
 PYTHON_MINOR_VERSION = 7
 REQUIREMENTS = """\
 Flask==1.1.1
-Pillow==8.1.1
+Pillow==8.2.0
 PyYAML==5.4
 boto3==1.14.62
 botocore==1.17.62


### PR DESCRIPTION
*Description of changes:*

Install the latest version of Pillow to fix CVEs:
CVE-2021-25289 (CRITICAL)
CVE-2021-25290 (HIGH)
CVE-2021-25291 (HIGH)
CVE-2021-25292 (MEDIUM)
CVE-2021-25293 (HIGH)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
