### PR TITLE
Support early stopping on 1.2-2

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -195,8 +195,10 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
     # Evaluation metrics to use with train() API
     tuning_objective_metric_param = train_cfg.pop("_tuning_objective_metric", None)
     eval_metric = train_cfg.get("eval_metric")
-    cleaned_eval_metric, configured_feval = train_utils.get_eval_metrics_and_feval(
+
+    cleaned_eval_metric, configured_feval, maximize_feval_metric = train_utils.get_eval_metrics_and_feval(
         tuning_objective_metric_param, eval_metric)
+
     if cleaned_eval_metric:
         train_cfg['eval_metric'] = cleaned_eval_metric
     else:
@@ -217,7 +219,8 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
 
             bst = xgb.train(train_cfg, train_dmatrix, num_boost_round=num_round-iteration, evals=watchlist,
                             feval=configured_feval, early_stopping_rounds=early_stopping_rounds,
-                            callbacks=callbacks, xgb_model=xgb_model, verbose_eval=False)
+                            maximize=maximize_feval_metric, callbacks=callbacks, xgb_model=xgb_model,
+                            verbose_eval=False)
 
         else:
             num_cv_round = train_cfg.pop("_num_cv_round", 1)
@@ -249,7 +252,7 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
                 logging.info("Train cross validation fold {}".format((len(bst) % kfold) + 1))
                 booster = xgb.train(train_cfg, cv_train_dmatrix, num_boost_round=num_round-iteration,
                                     evals=watchlist, feval=configured_feval, evals_result=evals_result,
-                                    early_stopping_rounds=early_stopping_rounds,
+                                    early_stopping_rounds=early_stopping_rounds, maximize=maximize_feval_metric,
                                     callbacks=callbacks, xgb_model=xgb_model, verbose_eval=False)
                 bst.append(booster)
                 evals_results.append(evals_result)

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -133,9 +133,9 @@ CUSTOM_METRICS = {
 }
 
 
-def get_custom_metrics(eval_metrics):
+def get_custom_metrics(union_metrics):
     """Get container defined metrics from metrics list."""
-    return set(eval_metrics).intersection(CUSTOM_METRICS.keys())
+    return [metric for metric in union_metrics if metric in CUSTOM_METRICS.keys()]
 
 
 def configure_feval(custom_metric_list):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To support XGBoost early stopping on customer metric, one need to make sure 
1) the customer metric is in the end of the metrics list.
2) Set maximize option correctly for customer metric (passed through feval).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
