### PR TITLE
Update smdebug version to 1.0.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.2.0
 scikit-learn==0.23.2
 scipy==1.5.3
-smdebug==1.0.7
+smdebug==1.0.8
 urllib3==1.25.9
 wheel==0.35.1

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -26,7 +26,7 @@ sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.2.0
 scikit-learn==0.23.2
 scipy==1.5.3
-smdebug==1.0.7
+smdebug==1.0.8
 urllib3==1.25.9
 wheel==0.35.1
 """.strip()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update smdebug version to 1.0.10. Adds error handling when the customer is using the default smdebug configuration.

See awslabs/sagemaker-debugger#496 for more info.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
