### PR TITLE
Add arm64 dockerfile

### DIFF
--- a/docker/1.3-1/base/Dockerfile_arm64.cpu
+++ b/docker/1.3-1/base/Dockerfile_arm64.cpu
@@ -1,0 +1,105 @@
+ARG UBUNTU_VERSION=18.04
+ARG IMAGE_DIGEST=c60266b67f58fafc30703315f617a8fcccaffc48ef5534ca5f67a9ba3aceb3b8
+
+FROM ubuntu:18.04
+
+ARG MINICONDA_VERSION=4.9.2
+ARG CONDA_PY_VERSION=39
+ARG CONDA_CHECKSUM="af1c16d821569ebf1bdaf549fcba7d27"
+ARG CONDA_PKG_VERSION=4.10.1
+ARG PYTHON_VERSION=3.7.10
+ARG PYARROW_VERSION=1.0
+ARG MLIO_VERSION=arch-agnostic
+ARG XGBOOST_VERSION=1.3.3
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+
+# Python won’t try to write .pyc or .pyo files on the import of source modules
+# Force stdin, stdout and stderr to be totally unbuffered. Good for logging
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONIOENCODING='utf-8'
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install --no-install-recommends \
+        build-essential \
+        curl \
+        git \
+        jq \
+        libatlas-base-dev \
+        nginx \
+        openjdk-8-jdk-headless \
+        unzip \
+        wget \
+        ca-certificates \
+        autoconf \
+        automake \
+        build-essential \
+        libssl-dev \
+        && \
+    # MLIO build dependencies
+    # Official Ubuntu APT repositories do not contain an up-to-date version of CMake required to build MLIO.
+    # Kitware contains the latest version of CMake.
+    wget https://cmake.org/files/v3.18/cmake-3.18.4.tar.gz && \
+    tar -xzvf cmake-3.18.4.tar.gz && \
+    cd cmake-3.18.4 && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install && \
+    apt-get install -y --no-install-recommends \
+        doxygen \
+        libcurl4-openssl-dev \
+        libtool \
+        ninja-build \
+        python3-dev \
+        python3-distutils \
+        python3-pip \
+        zlib1g-dev \
+        && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install conda
+RUN cd /tmp && \
+    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-py${CONDA_PY_VERSION}_${MINICONDA_VERSION}-Linux-aarch64.sh && \
+    echo "${CONDA_CHECKSUM} /tmp/Miniconda3.sh" | md5sum -c - && \
+    bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
+    rm /tmp/Miniconda3.sh
+
+ENV PATH=/miniconda3/bin:${PATH}
+
+# Install MLIO with Apache Arrow integration
+# We could install mlio-py from conda, but it comes  with extra support such as image reader that increases image size
+# which increases training time. We build from source to minimize the image size.
+RUN echo "conda ${CONDA_PKG_VERSION}" >> /miniconda3/conda-meta/pinned && \
+    # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
+    conda config --system --set auto_update_conda false && \
+    conda config --system --set show_channel_urls true && \
+    echo "python ${PYTHON_VERSION}.*" >> /miniconda3/conda-meta/pinned && \
+    conda install -c conda-forge python=${PYTHON_VERSION} && \
+    conda install conda=${CONDA_PKG_VERSION} && \
+    conda update -y conda && \
+    conda install -c conda-forge pyarrow=${PYARROW_VERSION} && \
+    cd /tmp && \
+    git clone --branch ${MLIO_VERSION} https://github.com/awslabs/ml-io.git mlio && \
+    cd mlio && \
+    build-tools/build-dependency build/third-party all && \
+    mkdir -p build/release && \
+    cd build/release && \
+    cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH="$(pwd)/../third-party" ../.. && \
+    cmake --build . && \
+    cmake --build . --target install && \
+    cmake -DMLIO_INCLUDE_PYTHON_EXTENSION=ON -DMLIO_INCLUDE_ARROW_INTEGRATION=ON ../.. && \
+    cmake --build . --target mlio-py && \
+    cmake --build . --target mlio-arrow && \
+    cd ../../src/mlio-py && \
+    python3 setup.py bdist_wheel && \
+    python3 -m pip install dist/*.whl && \
+    cp -r /tmp/mlio/build/third-party/lib/libtbb* /usr/local/lib/ && \
+    ldconfig && \
+    rm -rf /tmp/mlio
+
+# Install latest version of XGBoost
+RUN python3 -m pip install --no-cache -I xgboost==${XGBOOST_VERSION}

--- a/docker/1.3-1/final/Dockerfile.cpu
+++ b/docker/1.3-1/final/Dockerfile.cpu
@@ -15,7 +15,7 @@ RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 # Copy wheel to container #
 ###########################
 COPY dist/sagemaker_xgboost_container-2.0-py2.py3-none-any.whl /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
-RUN rm -rf /miniconda3/lib/python3.7/site-packages/numpy-1.19.4.dist-info && \
+RUN rm -rf /miniconda3/lib/python3.7/site-packages/numpy-1.21.0.dist-info && \
     python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
     python3 -m pip uninstall -y typing && \
     rm /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl


### PR DESCRIPTION
* needed for multiarch and graviton support

* also version bump numpy installer workaround

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
