### PR TITLE
Remove hardcoded payload limit

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/serve.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve.py
@@ -33,17 +33,7 @@ SUPPORTED_ACCEPTS = ["application/json", "application/jsonlines", "application/x
 logging = integration.setup_main_logger(__name__)
 
 
-def _get_max_content_length():
-    max_payload_size = 20 * 1024 ** 2
-    # NOTE: 6 MB max content length = 6 * 1024 ** 2
-    content_len = int(os.getenv("MAX_CONTENT_LENGTH", '6291456'))
-    if content_len < max_payload_size:
-        return content_len
-    else:
-        return max_payload_size
-
-
-PARSED_MAX_CONTENT_LENGTH = _get_max_content_length()
+PARSED_MAX_CONTENT_LENGTH = int(os.getenv("MAX_CONTENT_LENGTH", '6291456'))
 
 
 def number_of_workers():


### PR DESCRIPTION
*Issue #, if available:*

Even though we have a user configurable MAX_CONTENT_LENGTH is setting, we still enforce a hardcoded upper limit. This is no longer needed because the original requester of the limit no longer has this requirement and is actually asking for this limit to be removed as they have their own checking proceses.

*Description of changes:*

Remove upper limit on PARSED_MAX_CONTENT_LENGTH. That variable is is normally set by env var MAX_CONTENT_LENGTH but was restricted to under 20MB before, now there is no limit. (A default is still retained).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
