### PR TITLE
Swap version bump method for pip

### DIFF
--- a/docker/1.3-1/base/Dockerfile.cpu
+++ b/docker/1.3-1/base/Dockerfile.cpu
@@ -103,7 +103,8 @@ RUN echo "conda ${CONDA_PKG_VERSION}" >> /miniconda3/conda-meta/pinned && \
     cmake --build . --target mlio-arrow && \
     cd ../../src/mlio-py && \
     python3 setup.py bdist_wheel && \
-    conda update -y pip && \
+    python3 -m pip install typing && \
+    python3 -m pip install --upgrade pip && \
     python3 -m pip install dist/*.whl && \
     cp -r /tmp/mlio/build/third-party/lib/intel64/gcc4.7/* /usr/local/lib/ && \
     ldconfig && \

--- a/docker/1.3-1/base/Dockerfile_arm64.cpu
+++ b/docker/1.3-1/base/Dockerfile_arm64.cpu
@@ -96,7 +96,8 @@ RUN echo "conda ${CONDA_PKG_VERSION}" >> /miniconda3/conda-meta/pinned && \
     cmake --build . --target mlio-arrow && \
     cd ../../src/mlio-py && \
     python3 setup.py bdist_wheel && \
-    conda update -y pip && \
+    python3 -m pip install typing && \
+    python3 -m pip install --upgrade pip && \
     python3 -m pip install dist/*.whl && \
     cp -r /tmp/mlio/build/third-party/lib/libtbb* /usr/local/lib/ && \
     ldconfig && \


### PR DESCRIPTION
*Issue #, if available:*

Fix pip security vulnerability that was not addressed in previous commit.

*Description of changes:*

There was a faulty validation process that caused this to slip. Only using pip to upgrade pip works, using conda to update pip does not fix security vulnerability

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
