### PR TITLE
dependabot security bump pillow and urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4.1
-Pillow==8.3.0
+Pillow==8.3.2
 boto3==1.17.52
 botocore==1.20.52
 cryptography==3.4.7
@@ -18,5 +18,5 @@ sagemaker-inference==1.5.5
 scikit-learn==0.24.1
 scipy==1.6.2
 smdebug==1.0.10
-urllib3==1.26.4
+urllib3==1.26.5
 wheel==0.36.2

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -6,7 +6,7 @@ PYTHON_MAJOR_VERSION = 3
 PYTHON_MINOR_VERSION = 7
 REQUIREMENTS = """\
 Flask==1.1.1
-Pillow==8.3.0
+Pillow==8.3.2
 PyYAML==5.4.1
 boto3==1.17.52
 botocore==1.20.52
@@ -27,7 +27,7 @@ sagemaker-inference==1.5.5
 scikit-learn==0.24.1
 scipy==1.6.2
 smdebug==1.0.10
-urllib3==1.26.4
+urllib3==1.26.5
 wheel==0.36.2
 """.strip()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump pillow
CVE-2021-23437 Raise ValueError if color specifier is too long [hugovk, radarhere]

Bump urllib3
dependabot flag: https://github.com/aws/sagemaker-xgboost-container/pull/202

Couldn't just rely on dependabot since it did not update testing dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
