### PR TITLE
dependabot security bump pillow and urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4
 Pillow==8.3.2
 boto3==1.14.62
-botocore==1.17.62
+urllib3==1.20.52
 cryptography==3.4.6
 gunicorn==19.10.0
 matplotlib==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4
-Pillow==8.3.0
+Pillow==8.3.2
 boto3==1.14.62
 botocore==1.17.62
 cryptography==3.4.6
@@ -18,5 +18,5 @@ sagemaker-inference==1.2.0
 scikit-learn==0.23.2
 scipy==1.5.3
 smdebug==1.0.10
-urllib3==1.25.9
+urllib3==1.26.5
 wheel==0.35.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4
 Pillow==8.3.2
 boto3==1.14.62
-urllib3==1.20.52
+botocore==1.20.52
 cryptography==3.4.6
 gunicorn==19.10.0
 matplotlib==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4
 Pillow==8.3.2
-boto3==1.14.62
+boto3==1.17.52
 botocore==1.20.52
 cryptography==3.4.6
 gunicorn==19.10.0

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -6,7 +6,7 @@ PYTHON_MAJOR_VERSION = 3
 PYTHON_MINOR_VERSION = 7
 REQUIREMENTS = """\
 Flask==1.1.1
-Pillow==8.3.0
+Pillow==8.3.2
 PyYAML==5.4
 boto3==1.14.62
 botocore==1.17.62
@@ -27,7 +27,7 @@ sagemaker-inference==1.2.0
 scikit-learn==0.23.2
 scipy==1.5.3
 smdebug==1.0.10
-urllib3==1.25.9
+urllib3==1.26.5
 wheel==0.35.1
 """.strip()
 

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -8,7 +8,7 @@ REQUIREMENTS = """\
 Flask==1.1.1
 Pillow==8.3.2
 PyYAML==5.4
-boto3==1.14.62
+boto3==1.17.52
 botocore==1.20.52
 conda==4.9.0
 cryptography==3.4.6

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -9,7 +9,7 @@ Flask==1.1.1
 Pillow==8.3.2
 PyYAML==5.4
 boto3==1.14.62
-botocore==1.17.62
+urllib3==1.20.52
 conda==4.9.0
 cryptography==3.4.6
 gunicorn==19.10.0

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -9,7 +9,7 @@ Flask==1.1.1
 Pillow==8.3.2
 PyYAML==5.4
 boto3==1.14.62
-urllib3==1.20.52
+botocore==1.20.52
 conda==4.9.0
 cryptography==3.4.6
 gunicorn==19.10.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump pillow
CVE-2021-23437 Raise ValueError if color specifier is too long [hugovk, radarhere]

Bump urllib3
dependabot flag: #202

Couldn't just rely on dependabot since it did not update testing dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
