### PR TITLE
Case2272044573

### DIFF
--- a/src/sagemaker_xgboost_container/data_utils.py
+++ b/src/sagemaker_xgboost_container/data_utils.py
@@ -530,7 +530,7 @@ def get_dmatrix(data_path, content_type, csv_weights=0, is_pipe=False):
             files_path = "/tmp/sagemaker_xgboost_input_data"
             shutil.rmtree(files_path, ignore_errors=True)
             os.mkdir(files_path)
-            for path in data_path:
+            for path in set(data_path):
                 if not os.path.exists(path):
                     return None
                 if os.path.isfile(path):

--- a/test/unit/test_encoder.py
+++ b/test/unit/test_encoder.py
@@ -24,7 +24,7 @@ import xgboost as xgb
 from sagemaker_xgboost_container import encoder
 
 
-@pytest.mark.parametrize('target', ('42,6,9', '42.0,6.0,9.0', '42\n6\n9\n'))
+@pytest.mark.parametrize('target', ('42,6,9', '42.0,6.0,9.0', '42\n6\n9\n', b'42,6,9', b'42.0,6.0,9.0', b'42\n6\n9\n'))
 def test_csv_to_dmatrix(target):
     actual = encoder.csv_to_dmatrix(target)
     assert type(actual) is xgb.DMatrix

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,6 @@ deps =
     xgboostlatest: xgboost
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-conda_deps=
-    pyarrow=1.0.0
-    mlio-py=0.7.0
-conda_channels=
-    conda-forge
-    mlio
 commands =
     pytest --cov=sagemaker_xgboost_container --cov-fail-under=60 test/unit # increase minimum bar over time (75%+)
 


### PR DESCRIPTION
FileExistsError when both train and validation dataset contain files with the same name

Changed the `data_path` to set so that it will remove the duplicate while creating the symlink and symlink creation won't fail anymore


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
