### PR TITLE
upgrading pillow to 9.0.0 to address high security risks from CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4
-Pillow==8.3.2
+Pillow==9.0.0
 boto3==1.17.52
 botocore==1.20.52
 cryptography==3.4.6

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -6,7 +6,7 @@ PYTHON_MAJOR_VERSION = 3
 PYTHON_MINOR_VERSION = 7
 REQUIREMENTS = """\
 Flask==1.1.1
-Pillow==8.3.2
+Pillow==9.0.0
 PyYAML==5.4
 boto3==1.17.52
 botocore==1.20.52


### PR DESCRIPTION
Issue #, if available:
High Severity risk detected:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22817
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22816
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22815

Description of changes:
Updated pillow dependency to 9.0.0

Testing:
pytest test/unit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.