### PR TITLE
Using keyring to prevent GPG key from being outdated

### DIFF
--- a/docker/1.3-1/base/Dockerfile.cpu
+++ b/docker/1.3-1/base/Dockerfile.cpu
@@ -47,9 +47,10 @@ RUN apt-get update && \
         && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
         gpg --dearmor - | \
-        tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
+        tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
     apt-get update && \
+    rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
     apt-get install -y --no-install-recommends \
         autoconf \
         automake \
@@ -57,6 +58,7 @@ RUN apt-get update && \
         cmake=3.18.4-0kitware1 \
         cmake-data=3.18.4-0kitware1 \
         doxygen \
+        kitware-archive-keyring \
         libcurl4-openssl-dev \
         libssl-dev \
         libtool \


### PR DESCRIPTION
*Issue #*

*Description of changes:*
remove the downloaded key after signed the repo. Install the kitware-archive-keyring package to ensure that our keyring stays up to date as kitware rotate their keys

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
