### PR TITLE
Update numpy version from 1.20.3 to 1.21.0

### DIFF
--- a/docker/1.3-1/base/Dockerfile.cpu
+++ b/docker/1.3-1/base/Dockerfile.cpu
@@ -47,9 +47,10 @@ RUN apt-get update && \
         && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
         gpg --dearmor - | \
-        tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
+        tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
     apt-get update && \
+    rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
     apt-get install -y --no-install-recommends \
         autoconf \
         automake \
@@ -57,6 +58,7 @@ RUN apt-get update && \
         cmake=3.18.4-0kitware1 \
         cmake-data=3.18.4-0kitware1 \
         doxygen \
+        kitware-archive-keyring \
         libcurl4-openssl-dev \
         libssl-dev \
         libtool \

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cryptography==3.4.7
 gunicorn==19.10.0
 matplotlib==3.4.1
 multi-model-server==1.1.2
-numpy==1.20.3
+numpy==1.21.0
 pandas==1.2.4
 psutil==5.6.7  # sagemaker-containers requires psutil 5.6.7
 python-dateutil==2.8.1

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -15,7 +15,7 @@ cryptography==3.4.7
 gunicorn==19.10.0
 matplotlib==3.4.1
 multi-model-server==1.1.2
-numpy==1.20.3
+numpy==1.21.0
 pandas==1.2.4
 psutil==5.6.7
 pyarrow==1.0.1


### PR DESCRIPTION
*Issue #:*

*Description of changes:*
Bump up numpy version from 1.20.3 to 1.21.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
