### PR TITLE
Track buildspecs in repo like sklearn container

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -1,0 +1,62 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+      docker: 17
+  pre_build:
+    commands:
+    - echo Pre-build started on `date`
+    - echo Installing dependencies...
+    - curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    - bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3
+    - export PATH=/miniconda3/bin:${PATH}
+    - conda install python=3.7
+    - conda update -y conda
+    - conda install -y 'requests<2.21'  # sagemaker-python-sdk requires requests<2.21
+    - python3 -m pip install pip==20.1  # The new pip denpendency resolver in 20.2+ can't resolve 1.0-1 and 0.90 dependencies
+    - python3 -m pip install .[test]
+  build:
+    commands:
+    - echo Build started on `date`
+    - echo Docker login...
+    - docker login -u $dockerhub_username -p $dockerhub_password
+    - echo Building the Docker image...
+    - docker build -t xgboost-container-base:$FRAMEWORK_VERSION-cpu-py3 -f docker/$FRAMEWORK_VERSION/base/Dockerfile.cpu .
+    - python3 setup.py bdist_wheel --universal
+    - docker build -t preprod-xgboost-container:$FRAMEWORK_VERSION-cpu-py3 -f docker/$FRAMEWORK_VERSION/final/Dockerfile.cpu .
+    - echo Running tox...
+    - printf "FROM preprod-xgboost-container:$FRAMEWORK_VERSION-cpu-py3\nADD . /app\nWORKDIR /app\nRUN python3 -m pip install .[test]" > Dockerfile.test
+    - docker build -t test-xgboost-container -f Dockerfile.test .
+    - docker run --rm -t test-xgboost-container sh -c 'pytest --cov=sagemaker_xgboost_container --cov-fail-under=60 test/unit'
+    - docker run --rm -t test-xgboost-container sh -c 'flake8 setup.py src test'
+    - echo Running container tests...
+    - pytest test/integration/local --docker-base-name preprod-xgboost-container --tag $FRAMEWORK_VERSION-cpu-py3 --py-version 3 --framework-version $FRAMEWORK_VERSION
+    - docker tag preprod-xgboost-container:$FRAMEWORK_VERSION-cpu-py3 $SM_ALPHA.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:$FRAMEWORK_VERSION-cpu-py3
+    - docker tag preprod-xgboost-container:$FRAMEWORK_VERSION-cpu-py3 $SM_ALPHA.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:$FRAMEWORK_VERSION
+  post_build:
+    commands:
+    - echo Build completed on `date`
+    - |
+      case $CODEBUILD_WEBHOOK_EVENT in
+        PULL_REQUEST_MERGED)
+          echo Logging in to Amazon ECR...
+          $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+          echo Pushing the Docker image...
+          docker push $SM_ALPHA.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:$FRAMEWORK_VERSION-cpu-py3 | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"
+          docker push $SM_ALPHA.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:$FRAMEWORK_VERSION | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"
+          ;;
+        PULL_REQUEST_CREATED | PULL_REQUEST_UPDATED | PULL_REQUEST_REOPENED)
+          echo Logging in to Amazon ECR...
+          $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+          echo Pushing the Docker image...
+          # pushes test tag for manual verification, requires cleanup in ECR every once in a while though
+          TEST_TAG=$SM_ALPHA.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:${FRAMEWORK_VERSION}-cpu-py3-test
+          docker tag preprod-xgboost-container:$FRAMEWORK_VERSION-cpu-py3 ${TEST_TAG}
+          docker push ${TEST_TAG} | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"
+          ;;
+        *)
+          echo Undefined behavior for webhook event type $CODEBUILD_WEBHOOK_EVENT
+          ;;
+      esac

--- a/ci/buildspec_amd64.yml
+++ b/ci/buildspec_amd64.yml
@@ -1,0 +1,50 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+      docker: 19
+  pre_build:
+    commands:
+    - echo Pre-build started on `date`
+    - echo Installing dependencies...
+    - curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    - bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3
+    - export PATH=/miniconda3/bin:${PATH}
+    - conda install python=3.7
+    - conda update -y conda
+    - conda install -y 'requests<2.21'  # sagemaker-python-sdk requires requests<2.21
+    - python3 -m pip install pip==20.1  # The new pip denpendency resolver in 20.2+ can't resolve 1.0-1 and 0.90 dependencies
+    - python3 -m pip install .[test]
+  build:
+    commands:
+    - echo Build started on `date`
+    - echo Docker login...
+    - docker login -u $dockerhub_username -p $dockerhub_password
+    - echo Building the Docker image...
+    - CPU_TAG_SUFFIX=${FRAMEWORK_VERSION}-cpu-py3
+    - docker build -t xgboost-container-base:${CPU_TAG_SUFFIX} -f docker/$FRAMEWORK_VERSION/base/Dockerfile.cpu .
+    - python3 setup.py bdist_wheel --universal
+    - PREPROD_TAG=preprod-xgboost-container:${CPU_TAG_SUFFIX}
+    - docker build -t ${PREPROD_TAG} -f docker/$FRAMEWORK_VERSION/final/Dockerfile.cpu .
+    - echo Running tox...
+    - printf "FROM ${PREPROD_TAG}\nADD . /app\nWORKDIR /app\nRUN python3 -m pip install .[test]" > Dockerfile.test
+    - docker build -t test-xgboost-container -f Dockerfile.test .
+    - docker run --rm -t test-xgboost-container sh -c 'pytest --cov=sagemaker_xgboost_container --cov-fail-under=60 test/unit'
+    - docker run --rm -t test-xgboost-container sh -c 'flake8 setup.py src test'
+    - echo Running container tests...
+    - pytest test/integration/local --docker-base-name preprod-xgboost-container --tag ${CPU_TAG_SUFFIX} --py-version 3 --framework-version $FRAMEWORK_VERSION
+    - ECR_PREFIX=${SM_ALPHA}.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:${FRAMEWORK_VERSION}
+    - ECR_CPU_TAG=${ECR_PREFIX}-cpu-py3-amd64
+    - ECR_TAG=${ECR_PREFIX}-amd64
+    - docker tag ${PREPROD_TAG} ${ECR_CPU_TAG}
+    - docker tag ${PREPROD_TAG} ${ECR_TAG}
+  post_build:
+    commands:
+    - echo Build completed on `date`
+    - echo Logging in to Amazon ECR...
+    - $(aws ecr get-login --no-include-email --region us-west-2)
+    - echo Pushing the Docker image...
+    - docker push ${ECR_CPU_TAG} | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"
+    - docker push ${ECR_TAG} | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"

--- a/ci/buildspec_arm.yml
+++ b/ci/buildspec_arm.yml
@@ -1,0 +1,50 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+      docker: 19
+  pre_build:
+    commands:
+    - echo Pre-build started on `date`
+    - echo Installing dependencies...
+    - curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-aarch64.sh
+    - bash Miniconda3-latest-Linux-aarch64.sh -bfp /miniconda3
+    - export PATH=/miniconda3/bin:${PATH}
+    - conda install python=3.7
+    - conda update -y conda
+    - # conda install -y 'requests<2.21'  # sagemaker-python-sdk requires requests<2.21
+    - python3 -m pip install pip==20.1  # The new pip denpendency resolver in 20.2+ can't resolve 1.0-1 and 0.90 dependencies
+    - python3 -m pip install .[test]
+  build:
+    commands:
+    - echo Build started on `date`
+    - echo Docker login...
+    - docker login -u $dockerhub_username -p $dockerhub_password
+    - echo Building the Docker image...
+    - CPU_TAG_SUFFIX=${FRAMEWORK_VERSION}-cpu-py3-arm64
+    - docker build -t xgboost-container-base:${CPU_TAG_SUFFIX} -f docker/$FRAMEWORK_VERSION/base/Dockerfile_arm64.cpu .
+    - python3 setup.py bdist_wheel --universal
+    - PREPROD_TAG=preprod-xgboost-container:${CPU_TAG_SUFFIX}
+    - docker build -t ${PREPROD_TAG} -f docker/$FRAMEWORK_VERSION/final/Dockerfile_arm64.cpu .
+    - echo Running tox...
+    - printf "FROM ${PREPROD_TAG}\nADD . /app\nWORKDIR /app\nRUN python3 -m pip install .[test]" > Dockerfile.test
+    - docker build -t test-xgboost-container -f Dockerfile.test .
+    - docker run --rm -t test-xgboost-container sh -c 'pytest --cov=sagemaker_xgboost_container --cov-fail-under=60 test/unit'
+    - docker run --rm -t test-xgboost-container sh -c 'flake8 setup.py src test'
+    - echo Running container tests...
+    - pytest test/integration/local --docker-base-name preprod-xgboost-container --tag ${CPU_TAG_SUFFIX} --py-version 3 --framework-version $FRAMEWORK_VERSION
+    - ECR_PREFIX=${SM_ALPHA}.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:${FRAMEWORK_VERSION}
+    - ECR_CPU_TAG=${ECR_PREFIX}-cpu-py3-arm64
+    - ECR_TAG=${ECR_PREFIX}-arm64
+    - docker tag ${PREPROD_TAG} ${ECR_CPU_TAG}
+    - docker tag ${PREPROD_TAG} ${ECR_TAG}
+  post_build:
+    commands:
+    - echo Build completed on `date`
+    - echo Logging in to Amazon ECR...
+    - $(aws ecr get-login --no-include-email --region us-west-2)
+    - echo Pushing the Docker image...
+    - docker push ${ECR_CPU_TAG} | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"
+    - docker push ${ECR_TAG} | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"

--- a/ci/buildspec_multiarch.yml
+++ b/ci/buildspec_multiarch.yml
@@ -1,0 +1,37 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.7
+      docker: 19
+    commands:
+    - yum update -y
+  pre_build:
+    commands:
+    - echo Pre-build started on `date`
+    - echo Logging in to Amazon ECR...
+    - $(aws ecr get-login --no-include-email --region us-west-2)
+  build:
+    commands:
+    - echo Build started on `date`
+    - echo Buildling the Docker manifest...
+    - export DOCKER_CLI_EXPERIMENTAL=enabled
+    - echo Docker login...
+    - BASE_TAG=${SM_ALPHA}.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:${FRAMEWORK_VERSION}
+    - CPU_TAG=${BASE_TAG}-cpu-py3
+    - # Remove -multiarch suffix to overwrite previous tags
+    - docker manifest create ${BASE_TAG}-multiarch ${CPU_TAG}-arm64 ${CPU_TAG}-amd64
+    - docker manifest annotate --arch arm64 ${BASE_TAG}-multiarch ${CPU_TAG}-arm64
+    - docker manifest annotate --arch amd64 ${BASE_TAG}-multiarch ${CPU_TAG}-amd64
+    - docker manifest create ${CPU_TAG}-multiarch ${CPU_TAG}-arm64 ${CPU_TAG}-amd64
+    - docker manifest annotate --arch arm64 ${CPU_TAG}-multiarch ${CPU_TAG}-arm64
+    - docker manifest annotate --arch amd64 ${CPU_TAG}-multiarch ${CPU_TAG}-amd64
+  post_build:
+    commands:
+    - echo Build completed on `date`
+    - echo Pushing the Docker manifest...
+    - docker manifest push ${BASE_TAG}-multiarch
+    - docker manifest inspect ${BASE_TAG}-multiarch
+    - docker manifest push ${CPU_TAG}-multiarch
+    - docker manifest inspect ${CPU_TAG}-multiarch


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We want to unify our approach to continuous integration. Currently, our also maintained scikit-learn container (https://github.com/aws/sagemaker-scikit-learn-container/tree/master/ci) buildspecs are present within the repo. Instead of tracking the xgboost equivalents internally, we will now track these here in the repository. This also helps customers reproduce the build steps since those buildspecs are the ground truth for building these containers correctly.

At the moment, these files are just for reference, and internal logic changes can happen at their own pace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
