### PR TITLE
Pin flask dep itsdangerous

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ boto3==1.17.52
 botocore==1.20.52
 cryptography==3.4.7
 gunicorn==19.10.0
+itsdangerous==2.0.1
 matplotlib==3.4.1
 multi-model-server==1.1.2
 numpy==1.21.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A recent change in Flask's dependency itsdangerous causes it to remove support for its json functionality[1]. To resolve this, we can either (1) upgrade Flask to 2.0.1 or (2) pin itsdangerous to 2.0.1. Currently we are depending on sagemaker-containers[2] which hard depends on Flask 1.1.1. To go with approach 1, we'd need to refactor/update sagemaker-containers. This is the preferred long term approach but we should go with approach 2 for now to unblock other development efforts. Approach 2 is what was done already with the similar sklearn container[3].

[1] https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous
[2] https://github.com/aws/sagemaker-containers/
[3] https://github.com/aws/sagemaker-scikit-learn-container/pull/102

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

