### PR TITLE
Using ensemble flag for multi-model endpoint 1.2-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ src/sagemaker_xgboost_container.egg-info/
 __pycache__
 .coverage*
 .mypy_cache/
+.idea/

--- a/src/sagemaker_xgboost_container/algorithm_mode/handler_service.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/handler_service.py
@@ -45,7 +45,7 @@ class HandlerService(DefaultHandlerService):
                 XGBoost model format type.
             """
             try:
-                booster, format = serve_utils.get_loaded_booster(model_dir)
+                booster, format = serve_utils.get_loaded_booster(model_dir, serve_utils.is_ensemble_enabled())
             except Exception as e:
                 raise ModelLoadInferenceError("Unable to load model: {}".format(str(e)))
             return booster, format

--- a/src/sagemaker_xgboost_container/algorithm_mode/serve.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve.py
@@ -25,7 +25,6 @@ import gunicorn.app.base
 from sagemaker_xgboost_container.algorithm_mode import integration
 from sagemaker_xgboost_container.algorithm_mode import serve_utils
 from sagemaker_xgboost_container.constants import sm_env_constants
-from sagemaker_xgboost_container.constants.sm_env_constants import SAGEMAKER_INFERENCE_ENSEMBLE
 
 
 SAGEMAKER_BATCH = os.getenv(sm_env_constants.SAGEMAKER_BATCH)
@@ -143,8 +142,7 @@ class ScoringService(object):
 
 
 def load_model():
-    ensemble = os.environ.get(SAGEMAKER_INFERENCE_ENSEMBLE) != "false"
-    return ScoringService.load_model(ensemble=ensemble)
+    return ScoringService.load_model(ensemble=serve_utils.is_ensemble_enabled())
 
 
 @ScoringService.app.route("/ping", methods=["GET"])

--- a/src/sagemaker_xgboost_container/algorithm_mode/serve_utils.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve_utils.py
@@ -25,6 +25,7 @@ import xgboost as xgb
 from sagemaker_xgboost_container import encoder
 from sagemaker_xgboost_container.algorithm_mode import integration
 from sagemaker_xgboost_container.constants import sm_env_constants
+from sagemaker_xgboost_container.constants.sm_env_constants import SAGEMAKER_INFERENCE_ENSEMBLE
 from sagemaker_xgboost_container.data_utils import CSV, LIBSVM, RECORDIO_PROTOBUF, get_content_type
 from sagemaker_xgboost_container.constants.xgb_constants import (BINARY_HINGE, BINARY_LOG, BINARY_LOGRAW,
                                                                  MULTI_SOFTMAX, MULTI_SOFTPROB, REG_GAMMA,
@@ -457,3 +458,7 @@ def encode_selected_predictions(predictions, selected_content_keys, accept):
             return csv_response + '\n'
         return csv_response
     raise RuntimeError("Cannot encode selected predictions into accept type '{}'.".format(accept))
+
+
+def is_ensemble_enabled():
+    return os.environ.get(SAGEMAKER_INFERENCE_ENSEMBLE, "true") == "true"

--- a/test/unit/algorithm_mode/test_serve_utils.py
+++ b/test/unit/algorithm_mode/test_serve_utils.py
@@ -24,6 +24,7 @@ from sagemaker_containers._recordio import _read_recordio
 
 from sagemaker_algorithm_toolkit import exceptions as exc
 from sagemaker_xgboost_container import data_utils
+from sagemaker_xgboost_container.constants.sm_env_constants import SAGEMAKER_INFERENCE_ENSEMBLE
 from sagemaker_xgboost_container.data_utils import CSV, LIBSVM, RECORDIO_PROTOBUF
 from sagemaker_xgboost_container.algorithm_mode import serve_utils
 
@@ -259,3 +260,17 @@ def test_encode_selected_predictions_csv():
 def test_encode_selected_content_error():
     with pytest.raises(RuntimeError):
         serve_utils.encode_selected_predictions(TEST_PREDICTIONS, TEST_KEYS, "text/libsvm")
+
+
+def test_is_ensemble_enabled_var_not_set():
+    assert serve_utils.is_ensemble_enabled()
+
+
+def test_is_ensemble_enabled_var_set_to_false(monkeypatch):
+    monkeypatch.setenv(SAGEMAKER_INFERENCE_ENSEMBLE, 'false')
+    assert not serve_utils.is_ensemble_enabled()
+
+
+def test_is_ensemble_enabled_var_set_to_true(monkeypatch):
+    monkeypatch.setenv(SAGEMAKER_INFERENCE_ENSEMBLE, 'true')
+    assert serve_utils.is_ensemble_enabled()


### PR DESCRIPTION
For multi-model inference we do not pass the ensemble flag when selecting provided model files. This leads to a mismatch between multi-model and single-model inference output.

This CR makes the change to use ensemble method for multi-model, unless explicitly turned off by the user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.