### PR TITLE
Add supported response accept encodings to algorithm_mode

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/serve.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve.py
@@ -22,6 +22,7 @@ from gunicorn.six import iteritems
 import flask
 import gunicorn.app.base
 
+from sagemaker_containers.beta.framework import encoders
 from sagemaker_xgboost_container.algorithm_mode import integration
 from sagemaker_xgboost_container.algorithm_mode import serve_utils
 from sagemaker_xgboost_container.constants import sm_env_constants
@@ -225,19 +226,19 @@ def invocations():
         logging.exception(e)
         return flask.Response(response="Unable to evaluate payload provided: %s" % e, status=http.client.BAD_REQUEST)
 
-    if serve_utils.is_selectable_inference_output():
-        try:
-            accept = _parse_accept(flask.request)
-        except Exception as e:
-            logging.exception(e)
-            return flask.Response(response=str(e), status=http.client.NOT_ACCEPTABLE)
+    try:
+        accept = _parse_accept(flask.request)
+    except Exception as e:
+        logging.exception(e)
+        return flask.Response(response=str(e), status=http.client.NOT_ACCEPTABLE)
 
+    if serve_utils.is_selectable_inference_output():
         return _handle_selectable_inference_response(preds, accept)
 
     if SAGEMAKER_BATCH:
         return_data = "\n".join(map(str, preds.tolist())) + '\n'
     else:
-        return_data = ",".join(map(str, preds.tolist()))
+        return_data = encoders.encode(preds.tolist(), accept)
 
     return flask.Response(response=return_data, status=http.client.OK, mimetype="text/csv")
 

--- a/src/sagemaker_xgboost_container/algorithm_mode/serve.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve.py
@@ -240,7 +240,7 @@ def invocations():
     else:
         return_data = encoders.encode(preds.tolist(), accept)
 
-    return flask.Response(response=return_data, status=http.client.OK, mimetype="text/csv")
+    return flask.Response(response=return_data, status=http.client.OK, mimetype=accept)
 
 
 if __name__ == '__main__':

--- a/test/integration/local/test_abalone.py
+++ b/test/integration/local/test_abalone.py
@@ -114,6 +114,22 @@ def test_xgboost_abalone_inference(docker_image, opt_ml):
     assert len(response_body.split(",")) == 1
 
 
+def test_xgboost_abalone_algorithm_mode_inference(docker_image, opt_ml):
+    request_body = get_libsvm_request_body()
+
+    with local_mode.serve(
+        None, libsvm_model_dir, docker_image, opt_ml, source_dir=abalone_path
+    ):
+        response_status_code, response_body = local_mode.request(
+            request_body, content_type="text/libsvm", accept_type="application/json"
+        )
+
+    assert response_status_code == 200
+    assert not local_mode.file_exists(opt_ml, "output/failure"), "Failure happened"
+    assert len(response_body.split(",")) == 1
+    assert '[' in response_body
+
+
 def test_xgboost_abalone_custom_inference_with_transform_fn(docker_image, opt_ml):
     customer_script = "abalone_distributed.py"
     request_body = get_libsvm_request_body()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Sagemaker xgboost inference server already supports responses in the format of application/json and text/csv when using script_mode. In algorithm_mode, however, the code is hard coded to always return in the format text/csv. This change simply extends this response format support to algorithm_mode. This was simply missed from previous developments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
