### PR TITLE
Enabled HP validation for `sampling_method`

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -231,6 +231,7 @@ def initialize(metrics):
                                      required=False),
         hpv.CategoricalHyperparameter(name="single_precision_histogram", range=["true", "false"], required=False),
         hpv.CategoricalHyperparameter(name="deterministic_histogram", range=["true", "false"], required=False),
+        hpv.CategoricalHyperparameter(name="sampling_method", range=["uniform", "gradient_based"], required=False),
         )
 
     hyperparameters.declare_alias("eta", "learning_rate")


### PR DESCRIPTION
*Issue #, if available:*
`sampling_method` HP is not yet supported in container. 
*Description of changes:*
Added validation for `sampling_method` for version 1.3. [this HP was supported in XGBoost 1.3 version](https://xgboost.readthedocs.io/en/release_1.3.0/parameter.html#parameters-for-tree-booster) but our containers don't support it yet. Adding this validation check will enable the containers to use this HP for XGBoost-1.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
