### PR TITLE
Add warnings when validation files are suspected to be identical with training files

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -20,7 +20,8 @@ import xgboost as xgb
 from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold
 from sagemaker_algorithm_toolkit import exceptions as exc
 from sagemaker_algorithm_toolkit.channel_validation import Channel
-from sagemaker_xgboost_container.data_utils import get_content_type, get_dmatrix, get_size, validate_data_file_path
+from sagemaker_xgboost_container.data_utils import get_content_type, get_dmatrix, get_size, \
+    validate_data_file_path, check_data_redundancy
 from sagemaker_xgboost_container import distributed
 from sagemaker_xgboost_container import checkpointing
 from sagemaker_xgboost_container.algorithm_mode import channel_validation as cv
@@ -93,6 +94,8 @@ def get_validated_dmatrices(train_path, validate_path, content_type, csv_weights
         if train_path == validate_path or os.path.basename(train_path) == os.path.basename(validate_path):
             logger.warning('Found same path for training and validation. This is not recommended and results may not '
                            'be correct.')
+        else:
+            check_data_redundancy(train_path, validate_path)
         train_val_dmatrix = get_dmatrix([train_path, validate_path], content_type,
                                         csv_weights=csv_weights, is_pipe=is_pipe)
 

--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -95,6 +95,7 @@ def get_validated_dmatrices(train_path, validate_path, content_type, csv_weights
             logger.warning('Found same path for training and validation. This is not recommended and results may not '
                            'be correct.')
         else:
+            # Check if there is potential data redundancy between training and validation sets
             check_data_redundancy(train_path, validate_path)
         train_val_dmatrix = get_dmatrix([train_path, validate_path], content_type,
                                         csv_weights=csv_weights, is_pipe=is_pipe)

--- a/src/sagemaker_xgboost_container/data_utils.py
+++ b/src/sagemaker_xgboost_container/data_utils.py
@@ -634,27 +634,30 @@ def check_data_redundancy(train_path, validate_path):
     param train_path : path to training data
     param validate_path : path to validation data
 
+    return True if files suspected to be identical are found.
+           False otherwise.
+
     """
     if not os.path.exists(train_path):
-        exc.UserError("train path is not existed")
-        if not os.path.exists(validate_path):
-            exc.UserError("validate path is not existed")
+        exc.UserError("training data's path is not existed")
+    if not os.path.exists(validate_path):
+        exc.UserError("validation data's path is not existed")
 
     isRedundant = False
     training_files_set = set(f for f in os.listdir(train_path) if os.path.isfile(os.path.join(train_path, f)))
     validation_files_set = set(f for f in os.listdir(validate_path) if os.path.isfile(os.path.join(validate_path, f)))
     same_name_files = training_files_set.intersection(validation_files_set)
-    if len(same_name_files) != 0:
+    if same_name_files:
         for f in same_name_files:
-            f_train_name = os.path.join(train_path, f)
-            f_validate_name = os.path.join(validate_path, f)
-            f_train_size = os.path.getsize(f_train_name)
-            f_validate_size = os.path.getsize(f_validate_name)
+            f_train_path = os.path.join(train_path, f)
+            f_validate_path = os.path.join(validate_path, f)
+            f_train_size = os.path.getsize(f_train_path)
+            f_validate_size = os.path.getsize(f_validate_path)
             if f_train_size == f_validate_size:
                 isRedundant = True
                 logging.warning("Suspected identical files found. ({} and {} with same size {} bytes)."
-                                " Note: Duplicate data in the training set and validation set will"
-                                " greatly impair the validity of the model evaluation by"
+                                " Note: Duplicate data in the training set and validation set is usually"
+                                " not intentional and can impair the validity of the model evaluation by"
                                 " the validation score."
-                                .format(f_train_name, f_validate_name, f_validate_size))
+                                .format(f_train_path, f_validate_path, f_validate_size))
     return isRedundant

--- a/test/unit/test_data_utils.py
+++ b/test/unit/test_data_utils.py
@@ -247,5 +247,9 @@ class TestTrainUtils(unittest.TestCase):
 
     def test_check_data_redundancy(self):
         current_path = Path(os.path.abspath(__file__))
-        data_path = os.path.join(str(current_path.parent.parent), 'resources', 'abalone', 'data', 'train')
-        self.assertEqual(True, data_utils.check_data_redundancy(data_path, data_path))
+        data_path = os.path.join(str(current_path.parent.parent), 'resources', 'abalone', 'data')
+        file_path = os.path.join(data_path, "train")
+        self.assertEqual(True, data_utils.check_data_redundancy(file_path, file_path))
+
+        file_path = [os.path.join(data_path, path) for path in ['train', 'validation']]
+        self.assertEqual(False, data_utils.check_data_redundancy(file_path[0], file_path[1]))

--- a/test/unit/test_data_utils.py
+++ b/test/unit/test_data_utils.py
@@ -244,3 +244,8 @@ class TestTrainUtils(unittest.TestCase):
                 pb_path = os.path.join(self.data_path, 'recordio_protobuf', file_path)
                 reader = data_utils.get_recordio_protobuf_dmatrix
                 self._check_dmatrix(reader, pb_path, 1, 1)
+
+    def test_check_data_redundancy(self):
+        current_path = Path(os.path.abspath(__file__))
+        data_path = os.path.join(str(current_path.parent.parent), 'resources', 'abalone', 'data', 'train')
+        self.assertEqual(True, data_utils.check_data_redundancy(data_path, data_path))


### PR DESCRIPTION


*Description of changes:*
Add warnings when validation files are suspected to be identical with training files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
