### PR TITLE
added HP for `prob_buffer_row` remove after fixed in console

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -232,6 +232,7 @@ def initialize(metrics):
         hpv.CategoricalHyperparameter(name="single_precision_histogram", range=["true", "false"], required=False),
         hpv.CategoricalHyperparameter(name="deterministic_histogram", range=["true", "false"], required=False),
         hpv.CategoricalHyperparameter(name="sampling_method", range=["uniform", "gradient_based"], required=False),
+        hpv.IntegerHyperparameter(name="prob_buffer_row", range=hpv.Interval(min_open=1.0), required=False),
         )
 
     hyperparameters.declare_alias("eta", "learning_rate")


### PR DESCRIPTION
*Issue #, if available:*
Added a validation for `prob_buffer_row` to unblock the Console failures. This can be removed once fixed from console side. 
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
