### PR TITLE
Fix JSON output format

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/serve_utils.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/serve_utils.py
@@ -52,6 +52,10 @@ RAW_SCORES = "raw_scores"
 # regression selectable inference keys
 PREDICTED_SCORE = "predicted_score"
 
+# output keys for JSON response
+TOP_LEVEL_OUT_KEY = "predictions"
+SCORE_OUT_KEY = "score"
+
 # all supported selecable content keys
 ALL_VALID_SELECT_KEYS = [PREDICTED_LABEL, LABELS, PROBABILITY, PROBABILITIES, RAW_SCORE, RAW_SCORES, PREDICTED_SCORE]
 
@@ -458,6 +462,21 @@ def encode_selected_predictions(predictions, selected_content_keys, accept):
             return csv_response + '\n'
         return csv_response
     raise RuntimeError("Cannot encode selected predictions into accept type '{}'.".format(accept))
+
+
+def encode_predictions_as_json(predictions):
+    """Encode the selected predictions based on the JSON output format expected.
+        See https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html
+
+    :param predictions: list of predictions.
+    :return: encoded content in JSON
+        example: b'{"predictions": [{"score": 0.43861907720565796},
+        {"score": 0.4533972144126892}, {"score": 0.06351257115602493}]}'
+    """
+    preds_list_of_dict = []
+    for pred in predictions:
+        preds_list_of_dict.append({SCORE_OUT_KEY: pred})
+    return json.dumps({TOP_LEVEL_OUT_KEY: preds_list_of_dict})
 
 
 def is_ensemble_enabled():

--- a/test/integration/local/test_abalone.py
+++ b/test/integration/local/test_abalone.py
@@ -114,7 +114,22 @@ def test_xgboost_abalone_inference(docker_image, opt_ml):
     assert len(response_body.split(",")) == 1
 
 
-def test_xgboost_abalone_algorithm_mode_inference(docker_image, opt_ml):
+def test_xgboost_abalone_algorithm_mode_inference_csv_out(docker_image, opt_ml):
+    request_body = get_libsvm_request_body()
+
+    with local_mode.serve(
+        None, libsvm_model_dir, docker_image, opt_ml, source_dir=abalone_path
+    ):
+        response_status_code, response_body = local_mode.request(
+            request_body, content_type="text/libsvm", accept_type="text/csv"
+        )
+
+    assert response_status_code == 200
+    assert not local_mode.file_exists(opt_ml, "output/failure"), "Failure happened"
+    assert len(response_body.split(",")) == 1
+
+
+def test_xgboost_abalone_algorithm_mode_inference_json_out(docker_image, opt_ml):
     request_body = get_libsvm_request_body()
 
     with local_mode.serve(
@@ -126,8 +141,10 @@ def test_xgboost_abalone_algorithm_mode_inference(docker_image, opt_ml):
 
     assert response_status_code == 200
     assert not local_mode.file_exists(opt_ml, "output/failure"), "Failure happened"
-    assert len(response_body.split(",")) == 1
-    assert '[' in response_body
+
+    json_response = json.loads(response_body)
+    assert "predictions" in json_response
+    assert "score" in json_response.get("predictions")[0]
 
 
 def test_xgboost_abalone_custom_inference_with_transform_fn(docker_image, opt_ml):

--- a/test/unit/algorithm_mode/test_serve_utils.py
+++ b/test/unit/algorithm_mode/test_serve_utils.py
@@ -274,3 +274,13 @@ def test_is_ensemble_enabled_var_set_to_false(monkeypatch):
 def test_is_ensemble_enabled_var_set_to_true(monkeypatch):
     monkeypatch.setenv(SAGEMAKER_INFERENCE_ENSEMBLE, 'true')
     assert serve_utils.is_ensemble_enabled()
+
+
+def test_encode_predictions_as_json_empty_list():
+    expected_response = json.dumps({"predictions": []})
+    assert expected_response == serve_utils.encode_predictions_as_json([])
+
+
+def test_encode_predictions_as_json_non_empty_list():
+    expected_response = json.dumps({"predictions": [{"score": 0.43861907720565796}, {"score": 0.4533972144126892}]})
+    assert expected_response == serve_utils.encode_predictions_as_json([0.43861907720565796, 0.4533972144126892])

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,9 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 conda_deps=
-    pyarrow=0.16.0
-    mlio-py=0.6
+    pyarrow==1.0.1
+    tbb==2020.2
+    mlio-py==0.7.0
 conda_channels=
     conda-forge
     mlio


### PR DESCRIPTION
`Description`

We recently enabled prediction response in JSON(`accept=application/json`), for algorithm mode, but the output doesn't match expected format in our documentation. This PR updates the output format.

existing output sample: `b'[0.43861907720565796, 0.4533972144126892, 0.06351257115602493]'`
new output sample: `b'{"predictions": [{"score": 0.43861907720565796}, {"score": 0.4533972144126892}, {"score": 0.06351257115602493}]}'`

Note that this doesn't include output format update for json format.

The change in `tox.ini` is needed for me to run unit tests locally(Mac). Without specific dependency versions mlio doesn't properly load.

`Testing`

Unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.