### PR TITLE
fixed errors Case2272044573

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -20,7 +20,8 @@ import xgboost as xgb
 from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold
 from sagemaker_algorithm_toolkit import exceptions as exc
 from sagemaker_algorithm_toolkit.channel_validation import Channel
-from sagemaker_xgboost_container.data_utils import get_content_type, get_dmatrix, get_size, validate_data_file_path, check_data_redundancy
+from sagemaker_xgboost_container.data_utils import get_content_type, get_dmatrix, get_size, validate_data_file_path,\
+ check_data_redundancy
 from sagemaker_xgboost_container import distributed
 from sagemaker_xgboost_container import checkpointing
 from sagemaker_xgboost_container.algorithm_mode import channel_validation as cv

--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -20,7 +20,7 @@ import xgboost as xgb
 from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold
 from sagemaker_algorithm_toolkit import exceptions as exc
 from sagemaker_algorithm_toolkit.channel_validation import Channel
-from sagemaker_xgboost_container.data_utils import get_content_type, get_dmatrix, get_size, validate_data_file_path
+from sagemaker_xgboost_container.data_utils import get_content_type, get_dmatrix, get_size, validate_data_file_path, check_data_redundancy
 from sagemaker_xgboost_container import distributed
 from sagemaker_xgboost_container import checkpointing
 from sagemaker_xgboost_container.algorithm_mode import channel_validation as cv
@@ -138,9 +138,14 @@ def sagemaker_train(train_config, data_config, train_path, val_path, model_dir, 
     combine_train_val = '_kfold' in validated_train_config
     train_dmatrix, val_dmatrix, train_val_dmatrix = get_validated_dmatrices(train_path, val_path, file_type,
                                                                             csv_weights, is_pipe, combine_train_val)
-
     checkpoint_dir = checkpoint_config.get("LocalPath", None)
-
+    if val_path is not None:
+        if train_path == val_path or os.path.basename(train_path) == os.path.basename(val_path):
+            logger.warning('Found same path for training and validation. This is not recommended and results may not '
+                           'be correct.')
+        elif not is_pipe:
+            # Check if there is potential data redundancy between training and validation sets
+            check_data_redundancy(train_path, val_path)
     train_args = dict(
         train_cfg=validated_train_config,
         train_dmatrix=train_dmatrix,

--- a/src/sagemaker_xgboost_container/data_utils.py
+++ b/src/sagemaker_xgboost_container/data_utils.py
@@ -491,7 +491,6 @@ def _get_pipe_mode_files_path(data_path: Union[List[str], str]) -> List[str]:
     """
     :param data_path: Either directory or file
     """
-    # For pipe mode, we leverages mlio directly by creating a list of SageMakerPipe.
     if isinstance(data_path, list):
         files_path = data_path
     else:

--- a/src/sagemaker_xgboost_container/data_utils.py
+++ b/src/sagemaker_xgboost_container/data_utils.py
@@ -16,6 +16,8 @@ import logging
 import os
 import shutil
 
+from typing import List, Union
+
 import mlio
 from mlio.integ.arrow import as_arrow_file
 from mlio.integ.numpy import as_numpy
@@ -485,6 +487,52 @@ def get_recordio_protobuf_dmatrix(path, is_pipe=False):
         raise exc.UserError("Failed to load recordio-protobuf data with exception:\n{}".format(e))
 
 
+def _get_pipe_mode_files_path(data_path: Union[List[str], str]) -> List[str]:
+    """
+    :param data_path: Either directory or file
+    """
+    # For pipe mode, we leverages mlio directly by creating a list of SageMakerPipe.
+    if isinstance(data_path, list):
+        files_path = data_path
+    else:
+        files_path = [data_path]
+        if not os.path.exists(f"{data_path}_0"):
+            logging.info(f"Pipe path {data_path} does not exist!")
+            return None
+    return files_path
+
+
+def _get_file_mode_files_path(data_path: Union[List[str], str]) -> List[str]:
+    """
+    :param data_path: Either directory or file
+    """
+    # In file mode, we create a temp directory with symlink to all input files or
+    # directories to meet XGB's assumption that all files are in the same directory.
+
+    if isinstance(data_path, list):
+        logging.info('File path {} of input files'.format(data_path))
+        # Create a directory with symlinks to input files.
+        files_path = "/tmp/sagemaker_xgboost_input_data"
+        shutil.rmtree(files_path, ignore_errors=True)
+        os.mkdir(files_path)
+        for index, path in enumerate(data_path):
+            if not os.path.exists(path):
+                return None
+            if os.path.isfile(path):
+                _make_symlink(path, files_path, os.path.basename(path), index)
+            else:
+                for file in os.scandir(path):
+                    _make_symlink(file, files_path, file.name, index)
+
+    else:
+        if not os.path.exists(data_path):
+            logging.info('File path {} does not exist!'.format(data_path))
+            return None
+        files_path = get_files_path_from_string(data_path)
+
+    return files_path
+
+
 def get_dmatrix(data_path, content_type, csv_weights=0, is_pipe=False):
     """Create Data Matrix from CSV or LIBSVM file.
 
@@ -507,38 +555,13 @@ def get_dmatrix(data_path, content_type, csv_weights=0, is_pipe=False):
     # So the only way to combine the data is to read them in one shot.
     # Fortunately, milo can read multiple pipes together. So we extends
     # the parameter data_path to support list. If data_path is string as usual,
-    # get_dmatrix will work as before. When it is a list, we work as follows.
-    # For pipe mode, it leverages mlio directly by creating a list of SageMakerPipe.
-    # In file mode, we create a temp directory with symlink to all input files or
-    # directories to meet XGB's assumption that all files are in the same directory.
-    if is_pipe:
-        if isinstance(data_path, list):
-            files_path = data_path
-        else:
-            files_path = [data_path]
-            if not os.path.exists(data_path + '_0'):
-                logging.info('Pipe path {} does not exist!'.format(data_path))
-                return None
-    else:
-        if not isinstance(data_path, list):
-            if not os.path.exists(data_path):
-                logging.info('File path {} does not exist!'.format(data_path))
-                return None
-            files_path = get_files_path(data_path)
-        else:
-            # Create a directory with symlinks to input files.
-            files_path = "/tmp/sagemaker_xgboost_input_data"
-            shutil.rmtree(files_path, ignore_errors=True)
-            os.mkdir(files_path)
-            for path in data_path:
-                if not os.path.exists(path):
-                    return None
-                if os.path.isfile(path):
-                    os.symlink(path, os.path.join(files_path, os.path.basename(path)))
-                else:
-                    for file in os.scandir(path):
-                        os.symlink(file, os.path.join(files_path, file.name))
+    # get_dmatrix will work as before. When it is a list, it works as explained in respective functions.
 
+    if is_pipe:
+        files_path = _get_pipe_mode_files_path(data_path)
+    else:
+        files_path = _get_file_mode_files_path(data_path)
+    logging.info(f"files path: {files_path}")
     if content_type.lower() == CSV:
         dmatrix = get_csv_dmatrix(files_path, csv_weights, is_pipe)
     elif content_type.lower() == LIBSVM:
@@ -565,11 +588,11 @@ def get_size(data_path, is_pipe=False):
     :param is_pipe: Boolean to indicate if data is being read in pipe mode
     :return: Size of data or 1 if sagemaker pipe found
     """
-    if is_pipe and os.path.exists(data_path + '_0'):
-        logging.info('Pipe path {} found.'.format(data_path))
+    if is_pipe and os.path.exists(f"{data_path}_0"):
+        logging.info(f"Pipe path {data_path} found.")
         return 1
     if not os.path.exists(data_path):
-        logging.info('Path {} does not exist!'.format(data_path))
+        logging.info(f"Path {data_path} does not exist!")
         return 0
     else:
         total_size = 0
@@ -585,7 +608,7 @@ def get_size(data_path, is_pipe=False):
             return total_size
 
 
-def get_files_path(data_path):
+def get_files_path_from_string(data_path: Union[List[str], str]) -> List[str]:
     if os.path.isfile(data_path):
         files_path = data_path
     else:
@@ -595,3 +618,39 @@ def get_files_path(data_path):
                 break
 
     return files_path
+
+
+def _make_symlink(path, source_path, name, index):
+    base_name = os.path.join(source_path, f"{name}_{str(index)}")
+    logging.info(f'creating symlink between Path {source_path} and destination {base_name}')
+    os.symlink(path, base_name)
+
+
+def check_data_redundancy(train_path, validate_path):
+    """Log a warning if suspected duplicate files are found in the training and validation folders.
+
+    The validation score of models would be invalid if the same data is used for both training and validation.
+    Files are suspected of being duplicates when the file names are the same and their sizes are the same.
+
+    param train_path : path to training data
+    param validate_path : path to validation data
+    """
+    if not os.path.exists(train_path):
+        raise exc.UserError("training data's path is not existed")
+    if not os.path.exists(validate_path):
+        raise exc.UserError("validation data's path is not existed")
+
+    training_files_set = set(f for f in os.listdir(train_path) if os.path.isfile(os.path.join(train_path, f)))
+    validation_files_set = set(f for f in os.listdir(validate_path) if os.path.isfile(os.path.join(validate_path, f)))
+    same_name_files = training_files_set.intersection(validation_files_set)
+    for f in same_name_files:
+        f_train_path = os.path.join(train_path, f)
+        f_validate_path = os.path.join(validate_path, f)
+        f_train_size = os.path.getsize(f_train_path)
+        f_validate_size = os.path.getsize(f_validate_path)
+        if f_train_size == f_validate_size:
+            logging.warning(f"Suspected identical files found. ({f_train_path} and {f_validate_path}"
+                            f"with same size {f_validate_size} bytes)."
+                            f" Note: Duplicate data in the training set and validation set is usually"
+                            f" not intentional and can impair the validity of the model evaluation by"
+                            f" the validation score.")

--- a/src/sagemaker_xgboost_container/training.py
+++ b/src/sagemaker_xgboost_container/training.py
@@ -20,6 +20,7 @@ import sys
 from sagemaker_containers import _env
 import sagemaker_containers.beta.framework as framework
 from sagemaker_xgboost_container.algorithm_mode.train import sagemaker_train
+from sagemaker_xgboost_container.data_utils import check_data_redundancy
 from sagemaker_xgboost_container.constants import sm_env_constants
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,8 @@ def run_algorithm_mode():
 
     train_path = os.environ[sm_env_constants.SM_CHANNEL_TRAIN]
     val_path = os.environ.get(sm_env_constants.SM_CHANNEL_VALIDATION)
+
+  
 
     sm_hosts = json.loads(os.environ[sm_env_constants.SM_HOSTS])
     sm_current_host = os.environ[sm_env_constants.SM_CURRENT_HOST]

--- a/src/sagemaker_xgboost_container/training.py
+++ b/src/sagemaker_xgboost_container/training.py
@@ -20,7 +20,6 @@ import sys
 from sagemaker_containers import _env
 import sagemaker_containers.beta.framework as framework
 from sagemaker_xgboost_container.algorithm_mode.train import sagemaker_train
-from sagemaker_xgboost_container.data_utils import check_data_redundancy
 from sagemaker_xgboost_container.constants import sm_env_constants
 
 logger = logging.getLogger(__name__)
@@ -56,9 +55,6 @@ def run_algorithm_mode():
 
     train_path = os.environ[sm_env_constants.SM_CHANNEL_TRAIN]
     val_path = os.environ.get(sm_env_constants.SM_CHANNEL_VALIDATION)
-
-  
-
     sm_hosts = json.loads(os.environ[sm_env_constants.SM_HOSTS])
     sm_current_host = os.environ[sm_env_constants.SM_CURRENT_HOST]
 

--- a/test/unit/test_data_utils.py
+++ b/test/unit/test_data_utils.py
@@ -242,3 +242,17 @@ class TestTrainUtils(unittest.TestCase):
         file_path = [os.path.join(data_path, path) for path in ['train', 'validation']]
         data_utils.check_data_redundancy(file_path[0], file_path[1])
         mock_log_warning.assert_not_called()
+        
+    def test_check_data_redundancy_does_not_throw_exception_file(self):
+        current_path = Path(os.path.abspath(__file__))
+        data_path = os.path.join(str(current_path.parent.parent), 'resources', 'abalone', 'data')
+        file_path = os.path.join(data_path, "train")
+        try:
+            data_utils.check_data_redundancy(file_path, file_path)
+        except Exception as e:
+            assert False, f"check_data_redundancy raised an exception {e} for file mode"
+        
+    def test_check_data_redundancy_throws_exception_pipe(self):
+        pb_file_paths = ['pb_files']
+        with self.assertRaises(Exception):
+            data_utils.check_data_redundancy(pb_file_paths[0], pb_file_paths[1])

--- a/test/unit/test_data_utils.py
+++ b/test/unit/test_data_utils.py
@@ -19,6 +19,7 @@ import signal
 import subprocess
 import sys
 import time
+from mock import patch
 
 from sagemaker_algorithm_toolkit import exceptions as exc
 from sagemaker_xgboost_container import data_utils
@@ -225,3 +226,19 @@ class TestTrainUtils(unittest.TestCase):
                 pb_path = os.path.join(self.data_path, 'recordio_protobuf', file_path)
                 reader = data_utils.get_recordio_protobuf_dmatrix
                 self._check_dmatrix(reader, pb_path, 1, 1)
+
+    @patch("logging.warning")
+    def test_check_data_redundancy_positive(self, mock_log_warning):
+        current_path = Path(os.path.abspath(__file__))
+        data_path = os.path.join(str(current_path.parent.parent), 'resources', 'abalone', 'data')
+        file_path = os.path.join(data_path, "train")
+        data_utils.check_data_redundancy(file_path, file_path)
+        mock_log_warning.assert_called()
+
+    @patch("logging.warning")
+    def test_check_data_redundancy_negative(self, mock_log_warning):
+        current_path = Path(os.path.abspath(__file__))
+        data_path = os.path.join(str(current_path.parent.parent), 'resources', 'abalone', 'data')
+        file_path = [os.path.join(data_path, path) for path in ['train', 'validation']]
+        data_utils.check_data_redundancy(file_path[0], file_path[1])
+        mock_log_warning.assert_not_called()

--- a/test/unit/test_data_utils.py
+++ b/test/unit/test_data_utils.py
@@ -242,7 +242,7 @@ class TestTrainUtils(unittest.TestCase):
         file_path = [os.path.join(data_path, path) for path in ['train', 'validation']]
         data_utils.check_data_redundancy(file_path[0], file_path[1])
         mock_log_warning.assert_not_called()
-        
+
     def test_check_data_redundancy_does_not_throw_exception_file(self):
         current_path = Path(os.path.abspath(__file__))
         data_path = os.path.join(str(current_path.parent.parent), 'resources', 'abalone', 'data')
@@ -251,7 +251,7 @@ class TestTrainUtils(unittest.TestCase):
             data_utils.check_data_redundancy(file_path, file_path)
         except Exception as e:
             assert False, f"check_data_redundancy raised an exception {e} for file mode"
-        
+
     def test_check_data_redundancy_throws_exception_pipe(self):
         pb_file_paths = ['pb_files']
         with self.assertRaises(Exception):


### PR DESCRIPTION
*Issue #, if available:*
Fixed an issues with [Case2272044573](https://github.com/aws/sagemaker-xgboost-container/commit/81405a65db282a7bcae14c412ba000fde8aa5da4)
The issue was we were doing the data redundancy check, which relies on files for Pipe mode as well. 

*Description of changes:*
* Added a condition to not run file comparison check for Pipe mode
* All integ tests passed. `bb integration --image=515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.3-1.0.41-nraverka-test --stage=dev  `
```
----------------------------------------------------------- generated xml file: /workplace/nraverka/SMFrameworkXGBoost/src/SMFrameworksXGBoost1_3-1Tests/build/brazil-integ-tests/TEST-results.xml -----------------------------------------------------------
---------------------------- generated html file: /workplace/nraverka/SMFrameworkXGBoost/build/SMFrameworksXGBoost1_3-1Tests/SMFrameworksXGBoost1_3-1Tests-1.0/AL2_x86_64/DEV.STD.PTHREAD/build/brazil-unit-tests/python3.7.html -----------------------------
--------------------------- generated xml file: /workplace/nraverka/SMFrameworkXGBoost/build/SMFrameworksXGBoost1_3-1Tests/SMFrameworksXGBoost1_3-1Tests-1.0/AL2_x86_64/DEV.STD.PTHREAD/build/brazil-unit-tests/TEST-python3.7.xml ---------------------------
---------------------------- generated html file: /workplace/nraverka/SMFrameworkXGBoost/build/SMFrameworksXGBoost1_3-1Tests/SMFrameworksXGBoost1_3-1Tests-1.0/AL2_x86_64/DEV.STD.PTHREAD/build/brazil-unit-tests/python3.7.html -----------------------------
====================================================================================================================== warnings summary ======================================================================================================================
:68
  'pytest_runtest_protocol' hook uses deprecated __multicall__ argument

-- Docs: http://doc.pytest.org/en/latest/warnings.html
========================================================================================================== 122 passed, 1 warnings in 921.17 seconds ==========================================================================================================
BUILD SUCCEEDED


```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
