### PR TITLE
Reverting numpy 1.21.2 to 1.19.2 and adding regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gunicorn==19.10.0
 itsdangerous==2.0.1
 matplotlib==3.4.1
 multi-model-server==1.1.2
-numpy==1.21.6
+numpy==1.19.2
 pandas==1.2.4
 protobuf==3.20.1
 psutil==5.6.7  # sagemaker-containers requires psutil 5.6.7

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -15,7 +15,7 @@ cryptography==35.0.0
 gunicorn==19.10.0
 matplotlib==3.4.1
 multi-model-server==1.1.2
-numpy==1.21.6
+numpy==1.19.2
 pandas==1.2.4
 psutil==5.6.7
 pyarrow==1.0.1

--- a/test/unit/test_data_utils.py
+++ b/test/unit/test_data_utils.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 import unittest
 import os
 from pathlib import Path
+import pandas as pd
 import shutil
 import signal
 import subprocess
@@ -252,3 +253,7 @@ class TestTrainUtils(unittest.TestCase):
         pb_file_paths = ['pb_files']
         with self.assertRaises(Exception):
             data_utils.check_data_redundancy(pb_file_paths[0], pb_file_paths[1])
+
+    def test_pyarrow_to_parquet_conversion_does_not_throw_exception(self):
+        df = pd.DataFrame({'x': [1, 2]})
+        df.to_parquet('test.parquet', engine='pyarrow')


### PR DESCRIPTION
Issue #, if available:
* fixing https://github.com/aws/sagemaker-scikit-learn-container/issues/106 by reverting numpy version.
*  Added regression to verify the fix and catch the re occurrence of the issue. 
* Although the issue was reported in scikitlearn container, XGBoost uses same version of PyArrow. SO this is just a precautionary change. 

Description of changes:
* Numpy 1.2.x broke the integration with Pyarrow 1.0. Rolling back numpy version to 1.19.2
* Added regression test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.