### PR TITLE
Mix-in smdebug.xgboost.Hook and xgb.callback.TrainingCallback for callback compatibility in XGB-3.0.0+

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -28,6 +28,7 @@ from sagemaker_xgboost_container.algorithm_mode import channel_validation as cv
 from sagemaker_xgboost_container.algorithm_mode import hyperparameter_validation as hpv
 from sagemaker_xgboost_container.algorithm_mode import metrics as metrics_mod
 from sagemaker_xgboost_container.algorithm_mode import train_utils
+from sagemaker_xgboost_container.callback import add_debugging
 from sagemaker_xgboost_container.constants.xgb_constants import CUSTOMER_ERRORS, XGB_MAXIMIZE_METRICS
 from sagemaker_xgboost_container.constants.sm_env_constants import SM_OUTPUT_DATA_DIR
 from sagemaker_xgboost_container.prediction_utils import ValidationPredictionRecorder
@@ -231,6 +232,8 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
                 checkpoint_dir=checkpoint_dir, early_stopping_data_name=early_stopping_data_name,
                 early_stopping_metric=early_stopping_metric, early_stopping_rounds=early_stopping_rounds,
                 save_model_on_termination=save_model_on_termination, is_master=is_master)
+            add_debugging(callbacks=callbacks, hyperparameters=train_cfg, train_dmatrix=train_dmatrix,
+                          val_dmatrix=val_dmatrix)
 
             bst = xgb.train(train_cfg, train_dmatrix, num_boost_round=num_round-iteration, evals=watchlist,
                             feval=configured_feval, callbacks=callbacks, xgb_model=xgb_model, verbose_eval=False)
@@ -270,6 +273,9 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
                     checkpoint_dir=checkpoint_dir, early_stopping_data_name=early_stopping_data_name,
                     early_stopping_metric=early_stopping_metric, early_stopping_rounds=early_stopping_rounds,
                     save_model_on_termination=save_model_on_termination, is_master=is_master, fold=len(bst))
+                add_debugging(callbacks=callbacks, hyperparameters=train_cfg, train_dmatrix=cv_train_dmatrix,
+                              val_dmatrix=cv_val_dmatrix)
+
                 evals_result = {}
                 logging.info("Train cross validation fold {}".format((len(bst) % kfold) + 1))
                 booster = xgb.train(train_cfg, cv_train_dmatrix, num_boost_round=num_round-iteration,

--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -28,7 +28,6 @@ from sagemaker_xgboost_container.algorithm_mode import channel_validation as cv
 from sagemaker_xgboost_container.algorithm_mode import hyperparameter_validation as hpv
 from sagemaker_xgboost_container.algorithm_mode import metrics as metrics_mod
 from sagemaker_xgboost_container.algorithm_mode import train_utils
-from sagemaker_xgboost_container.callback import add_debugging
 from sagemaker_xgboost_container.constants.xgb_constants import CUSTOMER_ERRORS, XGB_MAXIMIZE_METRICS
 from sagemaker_xgboost_container.constants.sm_env_constants import SM_OUTPUT_DATA_DIR
 from sagemaker_xgboost_container.prediction_utils import ValidationPredictionRecorder
@@ -232,8 +231,6 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
                 checkpoint_dir=checkpoint_dir, early_stopping_data_name=early_stopping_data_name,
                 early_stopping_metric=early_stopping_metric, early_stopping_rounds=early_stopping_rounds,
                 save_model_on_termination=save_model_on_termination, is_master=is_master)
-            add_debugging(callbacks=callbacks, hyperparameters=train_cfg, train_dmatrix=train_dmatrix,
-                          val_dmatrix=val_dmatrix)
 
             bst = xgb.train(train_cfg, train_dmatrix, num_boost_round=num_round-iteration, evals=watchlist,
                             feval=configured_feval, callbacks=callbacks, xgb_model=xgb_model, verbose_eval=False)
@@ -273,9 +270,6 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
                     checkpoint_dir=checkpoint_dir, early_stopping_data_name=early_stopping_data_name,
                     early_stopping_metric=early_stopping_metric, early_stopping_rounds=early_stopping_rounds,
                     save_model_on_termination=save_model_on_termination, is_master=is_master, fold=len(bst))
-                add_debugging(callbacks=callbacks, hyperparameters=train_cfg, train_dmatrix=cv_train_dmatrix,
-                              val_dmatrix=cv_val_dmatrix)
-
                 evals_result = {}
                 logging.info("Train cross validation fold {}".format((len(bst) % kfold) + 1))
                 booster = xgb.train(train_cfg, cv_train_dmatrix, num_boost_round=num_round-iteration,

--- a/src/sagemaker_xgboost_container/callback.py
+++ b/src/sagemaker_xgboost_container/callback.py
@@ -1,8 +1,28 @@
 import logging
 from smdebug.xgboost import Hook
+import xgboost as xgb
 
 
 logger = logging.getLogger(__name__)
+
+
+class SmeDebugHook(xgb.callback.TrainingCallback, Hook):
+    """Mix-in callback class. smedebug.xgboost.Hook uses legacy callback style
+    and since XGB-3.0.0 mixing legacy callback instances with new TrainingCallback
+    instances is not allowed.
+    See: https://github.com/dmlc/xgboost/blob/v1.3.0/python-package/xgboost/training.py#L92-L93
+    :param hyperparameters: Dict of hyperparamters.
+                            Same as `params` in xgb.train(params, dtrain).
+    :param train_dmatrix: Training data set.
+    :param val_dmatrix: Validation data set.
+    """
+    def __init__(self, json_config_path, hyperparameters,
+                 train_dmatrix, val_dmatrix):
+        self = self.hook_from_config(json_config_path)
+        self.hyperparameters = hyperparameters
+        self.train_data = train_dmatrix
+        if val_dmatrix is not None:
+            self.validation_data = val_dmatrix
 
 
 def add_debugging(callbacks, hyperparameters, train_dmatrix,
@@ -17,13 +37,9 @@ def add_debugging(callbacks, hyperparameters, train_dmatrix,
                              instead of default config file.
     """
     try:
-        hook = Hook.hook_from_config(json_config_path)
-        hook.hyperparameters = hyperparameters
-        hook.train_data = train_dmatrix
-        if val_dmatrix is not None:
-            hook.validation_data = val_dmatrix
-        callbacks.append(hook)
+        hook = SmeDebugHook(json_config_path, hyperparameters, train_dmatrix, val_dmatrix)
         logging.info("Debug hook created from config")
     except Exception as e:
         logging.debug("Failed to create debug hook", e)
-        return
+    else:
+        callbacks.append(hook)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
from xgboost version 1.3.0 and later, all the callbacks consumed by xgb.train() must be instances of xgb.callback.TrainingCallback

we can't mixed new callbacks with Hook callback from smdebugger

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
