### PR TITLE
Fix custom metric miscalculation in distributed training

### DIFF
--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -100,8 +100,12 @@ CUSTOM_METRICS = {
 
 
 def get_custom_metrics(eval_metrics):
-    """Get container defined metrics from metrics list."""
-    return set(eval_metrics).intersection(CUSTOM_METRICS.keys())
+    """Get container defined metrics from metrics list.
+
+    The order of the returning custom metrics need to be consistent with the input for distributed training.
+    Otherwise, metrics reported from each host will be miscalculated in the master host. (P70679777)
+    """
+    return [eval_m for eval_m in eval_metrics if eval_m in CUSTOM_METRICS.keys()]
 
 
 def configure_feval(custom_metric_list):

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -110,6 +110,6 @@ def test_r2():
 
 class TestCustomMetric(unittest.TestCase):
     def test_get_custom_metrics(self):
-        eval_metrics = ["mse", "rmse", "mae", "r2", "wrong_metric"]
+        eval_metrics = ["mse", "f1", "r2", "wrong_metric"]
         res = get_custom_metrics(eval_metrics)
-        self.assertListEqual(res, ["mse", "rmse", "mae", "r2"])
+        self.assertListEqual(res, ["mse", "f1", "r2"])

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -13,7 +13,9 @@
 import numpy as np
 import xgboost as xgb
 from math import log
-from sagemaker_xgboost_container.metrics.custom_metrics import accuracy, f1, mse, r2
+import unittest
+from sagemaker_xgboost_container.metrics.custom_metrics import accuracy, f1, mse, r2, \
+    get_custom_metrics
 
 
 binary_train_data = np.random.rand(10, 2)
@@ -104,3 +106,10 @@ def test_r2():
     r2_score_name, r2_score_result = r2(regression_preds, regression_dtrain)
     assert r2_score_name == 'r2'
     assert r2_score_result == -1
+
+
+class TestCustomMetric(unittest.TestCase):
+    def test_get_custom_metrics(self):
+        eval_metrics = ["mse", "rmse", "mae", "r2", "wrong_metric"]
+        res = get_custom_metrics(eval_metrics)
+        self.assertListEqual(res, ["mse", "rmse", "mae", "r2"])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We need to maintain the order of custom_metric_list to prevent miscalculation of custom metrics in distributed training scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
