### PR TITLE
Updating Pillow version

### DIFF
--- a/docker/1.2-2/base/Dockerfile.cpu
+++ b/docker/1.2-2/base/Dockerfile.cpu
@@ -23,7 +23,13 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING='utf-8'
 
-RUN apt-get update && \
+RUN rm /etc/apt/sources.list.d/cuda.list && \
+    rm /etc/apt/sources.list.d/nvidia-ml.list && \
+    apt-key del 7fa2af80 && \
+    apt-get update && apt-get install -y --no-install-recommends wget && \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb && \
+    dpkg -i cuda-keyring_1.0-1_all.deb && \
+    apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install --no-install-recommends \
         build-essential \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4
-Pillow==9.1.1
+Pillow==9.1.0
 boto3==1.17.52
 botocore==1.20.52
 cryptography==35.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 PyYAML==5.4
-Pillow==9.0.0
+Pillow==9.1.1
 boto3==1.17.52
 botocore==1.20.52
 cryptography==35.0.0

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -6,7 +6,7 @@ PYTHON_MAJOR_VERSION = 3
 PYTHON_MINOR_VERSION = 7
 REQUIREMENTS = """\
 Flask==1.1.1
-Pillow==9.1.1
+Pillow==9.1.0
 PyYAML==5.4
 boto3==1.17.52
 botocore==1.20.52

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -6,7 +6,7 @@ PYTHON_MAJOR_VERSION = 3
 PYTHON_MINOR_VERSION = 7
 REQUIREMENTS = """\
 Flask==1.1.1
-Pillow==9.0.0
+Pillow==9.1.1
 PyYAML==5.4
 boto3==1.17.52
 botocore==1.20.52


### PR DESCRIPTION
Updating Pillow version as security scans show some critical vulnerabilities with the currently used version. Also added commands to update CUDA GPG repository key. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
