### PR TITLE
Maintain the order of union metric list in distributed training

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train_utils.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train_utils.py
@@ -33,7 +33,9 @@ def get_union_metrics(metric_a, metric_b):
     elif metric_b is None:
         return metric_a
     else:
-        metric_list = list(set(metric_a).union(metric_b))
+        # The order of metric_list need to be consistent among all hosts in distributed training
+        # So we have metric_list sorted here.
+        metric_list = sorted(list(set(metric_a).union(metric_b)))
         return metric_list
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A followup for https://github.com/aws/sagemaker-xgboost-container/pull/306 , need to maintain the order of union metrics if customer specifies eval_metric and tuning metric

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
