### PR TITLE
Maintain the order of union metric list in distributed training

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train_utils.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train_utils.py
@@ -33,7 +33,9 @@ def get_union_metrics(metric_a, metric_b):
     elif metric_b is None:
         return metric_a
     else:
-        metric_list = list(set(metric_a).union(metric_b))
+        # The order of metric_list need to be consistent among all hosts in distributed training
+        # So we have metric_list sorted here.
+        metric_list = sorted(list(set(metric_a).union(metric_b)))
         return metric_list
 
 

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -134,8 +134,12 @@ CUSTOM_METRICS = {
 
 
 def get_custom_metrics(eval_metrics):
-    """Get container defined metrics from metrics list."""
-    return set(eval_metrics).intersection(CUSTOM_METRICS.keys())
+    """Get container defined metrics from metrics list.
+
+    The order of the returning custom metrics need to be consistent with the input for distributed training.
+    Otherwise, metrics reported from each host will be miscalculated in the master host. (P70679777)
+    """
+    return [eval_m for eval_m in eval_metrics if eval_m in CUSTOM_METRICS.keys()]
 
 
 def configure_feval(custom_metric_list):

--- a/test/unit/algorithm_mode/test_custom_metrics.py
+++ b/test/unit/algorithm_mode/test_custom_metrics.py
@@ -13,7 +13,9 @@
 import numpy as np
 import xgboost as xgb
 from math import log
-from sagemaker_xgboost_container.metrics.custom_metrics import accuracy, f1, mse, r2, f1_binary, f1_macro
+import unittest
+from sagemaker_xgboost_container.metrics.custom_metrics import accuracy, f1, mse, r2, f1_binary, f1_macro, \
+    get_custom_metrics
 
 
 binary_train_data = np.random.rand(10, 2)
@@ -128,3 +130,10 @@ def test_r2():
     r2_score_name, r2_score_result = r2(regression_preds, regression_dtrain)
     assert r2_score_name == 'r2'
     assert r2_score_result == -1
+
+
+class TestCustomMetric(unittest.TestCase):
+    def test_get_custom_metrics(self):
+        eval_metrics = ["mse", "f1", "r2", "wrong_metric"]
+        res = get_custom_metrics(eval_metrics)
+        self.assertListEqual(res, ["mse", "f1", "r2"])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We need to maintain the order of custom_metric_list to prevent miscalculation of custom metrics in distributed training scenario.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
