### PR TITLE
Fixing buildspec to use conda env

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -1,9 +1,12 @@
 version: 0.2
 
+env:
+  shell: bash
+
 phases:
   install:
     runtime-versions:
-      python: 3.6
+      python: 3.7
       docker: 19
   pre_build:
     commands:
@@ -12,8 +15,8 @@ phases:
     - curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
     - bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3
     - export PATH=/miniconda3/bin:${PATH}
-    - conda install python=3.6
-    - conda update -y conda
+    - conda create -n py_3_6 python=3.6.13
+    - source $(conda info --base)/etc/profile.d/conda.sh && conda activate py_3_6
     - python3 -m pip install pip==20.1  # The new pip dependency resolver in 20.2+ can't resolve 1.0-1 and 0.90 dependencies
     - python3 -m pip install .[test]
   build:


### PR DESCRIPTION
Some issues with the previous build:

* Python runtime 3.7 is the lowest supported in CodeBuild https://docs.aws.amazon.com/codebuild/latest/userguide/runtime-versions.html
* conda install python=3.6 command fails in the runtime, with several dependency conflicts.

Using conda env to install Python 3.6. Activating the env is a bit tricky because of the requirement by conda to activate shell and restart, that's why the env activation code is a bit hacky.

Testing:
* Test image build.

Enabled pull request created option for the build temporarily.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.