### PR TITLE
Update Python version and vulnerable packages

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -15,8 +15,8 @@ phases:
     - curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
     - bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3
     - export PATH=/miniconda3/bin:${PATH}
-    - conda create -n py_3_6 python=3.6.13
-    - source $(conda info --base)/etc/profile.d/conda.sh && conda activate py_3_6
+    - conda create -n py_3_7 python=3.7.10
+    - source $(conda info --base)/etc/profile.d/conda.sh && conda activate py_3_7
     - python3 -m pip install pip==20.1  # The new pip dependency resolver in 20.2+ can't resolve 1.0-1 and 0.90 dependencies
     - python3 -m pip install .[test]
   build:
@@ -62,3 +62,4 @@ phases:
           echo Undefined behavior for webhook event type $CODEBUILD_WEBHOOK_EVENT
           ;;
       esac
+

--- a/docker/1.0-1/base/Dockerfile.cpu
+++ b/docker/1.0-1/base/Dockerfile.cpu
@@ -1,41 +1,54 @@
-FROM ubuntu:16.04
+ARG UBUNTU_VERSION=18.04
+ARG IMAGE_DIGEST=cd9842111e50ca15135bd04bccfeed4e1e63006ee7d2210927fc8f49bacb4ee8
+
+FROM ubuntu:${UBUNTU_VERSION}@sha256:${IMAGE_DIGEST}
+
+ARG MINICONDA_VERSION=4.8.3
+ARG CONDA_PY_VERSION=38
+ARG CONDA_CHECKSUM="d63adf39f2c220950a063e0529d4ff74"
+ARG CONDA_PKG_VERSION=4.9.0
+ARG PYTHON_VERSION=3.7.10
+ARG CRYPTO_VERSION=3.4.6 # Dist. training fails if 35.0.0 version is installed.
+ARG PYARROW_VERSION=0.14.1
+ARG MLIO_VERSION=0.1.3
+ARG XGBOOST_VERSION=1.0.0
 
 # Install python and other runtime dependencies
 RUN apt-get update && \
     apt-get -y install \
         build-essential \
-        libatlas-dev \
-        git \
-        wget \
         curl \
+        git \
+        jq \
+        libatlas-base-dev \
         nginx \
-        jq
+        openjdk-8-jdk-headless \
+        unzip \
+        wget
 
 RUN apt-get update
 RUN apt-get clean
 
-RUN apt-get -y install openjdk-8-jdk-headless
-
-# Install mlio
-RUN echo 'installing miniconda' && \
-    curl -LO https://repo.anaconda.com/miniconda/Miniconda3-py38_4.8.3-Linux-x86_64.sh && \
-    echo "d63adf39f2c220950a063e0529d4ff74 Miniconda3-py38_4.8.3-Linux-x86_64.sh" | md5sum -c - && \
-    bash Miniconda3-py38_4.8.3-Linux-x86_64.sh -bfp /miniconda3 && \
-    rm Miniconda3-py38_4.8.3-Linux-x86_64.sh
+# Install conda
+RUN cd /tmp && \
+    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-py${CONDA_PY_VERSION}_${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    echo "${CONDA_CHECKSUM} /tmp/Miniconda3.sh" | md5sum -c - && \
+    bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
+    rm /tmp/Miniconda3.sh
 
 ENV PATH=/miniconda3/bin:${PATH}
 
-RUN conda install -c conda-forge python=3.6.13 && \
+# Install MLIO with Apache Arrow integration
+RUN echo "conda ${CONDA_PKG_VERSION}" >> /miniconda3/conda-meta/pinned && \
+    # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
+    conda config --system --set auto_update_conda false && \
+    conda config --system --set show_channel_urls true && \
+    echo "python ${PYTHON_VERSION}.*" >> /miniconda3/conda-meta/pinned && \
+    conda install -c conda-forge python=${PYTHON_VERSION} cryptography=${CRYPTO_VERSION} && \
+    conda install conda=${CONDA_PKG_VERSION} && \
     conda update -y conda && \
-    conda install pip=20.1 && \
-    conda install -c conda-forge pyarrow=0.14.1 glog=0.4.0 tbb=2020.2 && \
-    conda install -c mlio -c conda-forge mlio-py=0.1
-
-# Python won’t try to write .pyc or .pyo files on the import of source modules
-# Force stdin, stdout and stderr to be totally unbuffered. Good for logging
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONIOENCODING='utf-8'
+    conda install -c conda-forge pyarrow=${PYARROW_VERSION} glog=0.4.0 tbb=2020.2 && \
+    conda install -c mlio -c conda-forge mlio-py=${MLIO_VERSION}
 
 # Install latest version of XGBoost
-RUN python3 -m pip install --no-cache -I xgboost==1.0
+RUN python3 -m pip install --no-cache -I xgboost==${XGBOOST_VERSION}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,27 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
+Pillow==9.1.1
 PyYAML==5.4.1
 boto3==1.17.52
 botocore==1.20.52
 gunicorn==19.10.0
 cryptography==3.4.6
+itsdangerous==2.0.1
 matplotlib==3.3.2
 multi-model-server==1.1.1
-numpy==1.19.2
 pandas==1.1.3
-protobuf==3.15.6
+protobuf==3.20.1
 psutil==5.6.7  # sagemaker-containers requires psutil 5.6.7
 python-dateutil==2.8.0
 requests==2.25.1
 retrying==1.3.3
 sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.2.0
-scikit-learn==0.23.2
+scikit-learn==0.24.1
 scipy==1.2.2
 smdebug==1.0.10
-urllib3==1.25.9
-wheel==0.35.1
+urllib3==1.26.5
+wheel==0.36.2
+jinja2==2.11.3
+MarkupSafe==1.1.1
+Werkzeug==0.15.6
+


### PR DESCRIPTION
*Description of changes:*
There are some critical vulnerabilities(in Pillow, joblib) which require updating Python versions. With this change the image size went up from 3.35GB to 4.6GB.

*Testing:*
* Integ test suite passed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
