### PR TITLE
MMS UseContainerSupport Flag

### DIFF
--- a/src/sagemaker_xgboost_container/serving_mms.py
+++ b/src/sagemaker_xgboost_container/serving_mms.py
@@ -102,6 +102,12 @@ def _set_mms_configs(is_multi_model, handler):
     # JVM configurations for MMS, exposed to users as env vars
     _set_default_if_not_exist("SAGEMAKER_MAX_HEAP_SIZE", str(max_heap_size) + "m")
     _set_default_if_not_exist("SAGEMAKER_MAX_DIRECT_MEMORY_SIZE", os.environ["SAGEMAKER_MAX_HEAP_SIZE"])
+    _set_default_if_not_exist("SAGEMAKER_MAX_DIRECT_MEMORY_SIZE", os.environ["SAGEMAKER_MAX_HEAP_SIZE"])
+
+    disable_container_support_flag = ""
+    if "SAGEMAKER_DISABLE_CONTAINER_SUPPORT" in os.environ \
+            and os.environ["SAGEMAKER_DISABLE_CONTAINER_SUPPORT"] == "true":
+        disable_container_support_flag = " -XX:-UseContainerSupport"
 
     MMS_CONFIG_FILE_PATH = get_mms_config_file_path()
 
@@ -123,6 +129,7 @@ def _set_mms_configs(is_multi_model, handler):
                     + os.environ["SAGEMAKER_MAX_HEAP_SIZE"]
                     + " -XX:MaxDirectMemorySize="
                     + os.environ["SAGEMAKER_MAX_DIRECT_MEMORY_SIZE"]
+                    + disable_container_support_flag
                     + "\n"
                 )
                 g.write(f.read())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Java-based application portion of MMS is unable to detect the actual number of CPU cores due to a back-ported change in Java. Disabling the container support flag that is now enabled by default restores the original behavior, which allows in proper computation of thread allocation and what-not.

I am not disabling by default as this will have impacts to current production workloads. In future versions/releases, however, this should be disabled by default.

*Testing:*
Ran integration tests against the generated image and confirmed the expected number of CPUs in a pre-prod environment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
