### PR TITLE
Fix dataframe operation after read

### DIFF
--- a/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
+++ b/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
@@ -32,7 +32,7 @@ def _read_data(local_path: str, content_type: str) -> (DataFrame, Series):
 
     target_column = dataframe.columns[0]
     labels = dataframe[target_column]
-    features = dataframe[dataframe.columns.difference([target_column])]
+    features = dataframe.drop(target_column, axis=1)
 
     return features, labels
 

--- a/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
+++ b/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
@@ -32,7 +32,7 @@ def _read_data(local_path: str, content_type: str) -> (DataFrame, Series):
 
     target_column = dataframe.columns[0]
     labels = dataframe[target_column]
-    features = dataframe.drop(target_column, axis=1)
+    features = dataframe[dataframe.columns[1:]]
 
     return features, labels
 


### PR DESCRIPTION
`dataframe.columns.difference`  returns a sorted list of column names, unless explicitly told not to sort. This messes up the feature order, if the dataframe column names were not sorted already.
Using drop() instead of modifying usage of `columns.difference`, as it looks cleaner.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
