### PR TITLE
Dask Flow Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 .mypy_cache/
 .idea/
 .DS_Store
+test.parquet

--- a/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/hyperparameter_validation.py
@@ -338,6 +338,8 @@ def initialize(metrics):
         hpv.CategoricalHyperparameter(name="deterministic_histogram", range=["true", "false"], required=False),
         hpv.CategoricalHyperparameter(name="sampling_method", range=["uniform", "gradient_based"], required=False),
         hpv.IntegerHyperparameter(name="prob_buffer_row", range=hpv.Interval(min_open=1.0), required=False),
+        # Not an XGB training HP, but is used to determine which distributed training framework to use by SM XGB.
+        hpv.CategoricalHyperparameter(name="use_dask_gpu_training", range=["true", "false"], required=False),
     )
 
     hyperparameters.declare_alias("eta", "learning_rate")

--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import logging
 import os
-import signal
 
 import numpy as np
 import xgboost as xgb
@@ -20,17 +19,19 @@ from sklearn.model_selection import RepeatedKFold, RepeatedStratifiedKFold
 
 from sagemaker_algorithm_toolkit import exceptions as exc
 from sagemaker_algorithm_toolkit.channel_validation import Channel
-from sagemaker_xgboost_container import checkpointing, distributed
+from sagemaker_xgboost_container import distributed
 from sagemaker_xgboost_container.algorithm_mode import channel_validation as cv
 from sagemaker_xgboost_container.algorithm_mode import hyperparameter_validation as hpv
 from sagemaker_xgboost_container.algorithm_mode import metrics as metrics_mod
 from sagemaker_xgboost_container.algorithm_mode import train_utils
-from sagemaker_xgboost_container.callback import add_debugging
-from sagemaker_xgboost_container.constants.sm_env_constants import SM_OUTPUT_DATA_DIR
+from sagemaker_xgboost_container.callback import add_debugging, get_callbacks
+from sagemaker_xgboost_container.constants.sm_env_constants import (
+    SM_NUM_GPUS,
+    SM_OUTPUT_DATA_DIR,
+)
 from sagemaker_xgboost_container.constants.xgb_constants import (
     CUSTOMER_ERRORS,
     MODEL_NAME,
-    XGB_MAXIMIZE_METRICS,
 )
 from sagemaker_xgboost_container.data_utils import (
     check_data_redundancy,
@@ -39,30 +40,12 @@ from sagemaker_xgboost_container.data_utils import (
     get_size,
     validate_data_file_path,
 )
+from sagemaker_xgboost_container.distributed_gpu import distributed_gpu_training
 from sagemaker_xgboost_container.prediction_utils import ValidationPredictionRecorder
 
 logger = logging.getLogger(__name__)
 
-
-def add_sigterm_handler(model_dir, is_master):
-    """Stop training and cleanup model directory when SIGTERM is received.
-
-    Model directory is only cleaned if is_master is True. Otherwise program terminates.
-
-    :param model_dir: Directory where model is saved
-    :param is_master: True if single node training, or the current node is the master node in distributed training
-    """
-
-    def _terminate():
-        os._exit(0)
-
-    def _cleanup_files(signo, frame):
-        if is_master:
-            train_utils.cleanup_dir(model_dir, MODEL_NAME)
-
-        _terminate()
-
-    signal.signal(signal.SIGTERM, _cleanup_files)
+DOCUMENTATION_LINK = "https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost.html"
 
 
 def get_validated_dmatrices(
@@ -169,50 +152,82 @@ def sagemaker_train(
     # Obtain information about training resources to determine which distributed setup to use, if needed.
     num_hosts = len(sm_hosts)
 
-    train_dmatrix, val_dmatrix, train_val_dmatrix = get_validated_dmatrices(
-        train_path, val_path, file_type, csv_weights, is_pipe, combine_train_val
-    )
     checkpoint_dir = checkpoint_config.get("LocalPath", None)
 
-    train_args = dict(
-        train_cfg=validated_train_config,
-        train_dmatrix=train_dmatrix,
-        val_dmatrix=val_dmatrix,
-        train_val_dmatrix=train_val_dmatrix,
-        model_dir=model_dir,
-        checkpoint_dir=checkpoint_dir,
-    )
+    num_gpus = int(os.getenv(SM_NUM_GPUS, 0))
+    logging.info(f"Determined {num_gpus} GPU(s) available on the instance.")
+    tree_method_hp = validated_train_config.get("tree_method")
 
-    if num_hosts > 1:
-        # Wait for hosts to find each other
-        logging.info("Distributed node training with {} hosts: {}".format(num_hosts, sm_hosts))
-        distributed.wait_hostname_resolution(sm_hosts)
+    is_dask_job = validated_train_config.pop("use_dask_gpu_training", "false")
 
-        if not train_dmatrix:
-            logging.warning(
-                "Host {} does not have data. Will broadcast to cluster and will not be used in distributed"
-                " training.".format(sm_current_host)
-            )
-        distributed.rabit_run(
-            exec_fun=train_job,
-            args=train_args,
-            include_in_training=(train_dmatrix is not None),
-            hosts=sm_hosts,
-            current_host=sm_current_host,
-            update_rabit_args=True,
+    if is_dask_job == "true":
+        distributed_gpu_training.check_if_all_conditions_met(
+            tree_method_hp=tree_method_hp,
+            num_hosts=num_hosts,
+            num_gpus=num_gpus,
+            input_mode=input_mode,
+            input_format=file_type,
+            data_config=validated_data_config,
         )
-    elif num_hosts == 1:
-        if train_dmatrix:
-            if validation_channel:
-                if not val_dmatrix:
-                    raise exc.UserError("No data in validation channel path {}".format(val_path))
-            logging.info("Single node training.")
-            train_args.update({"is_master": True})
-            train_job(**train_args)
-        else:
-            raise exc.UserError("No data in training channel path {}".format(train_path))
+        logging.info("Going to run distributed GPU training through Dask.")
+        distributed_gpu_training.run_training_with_dask(
+            hyperparameters=validated_train_config,
+            train_path=train_path,
+            validation_path=val_path,
+            model_dir=model_dir,
+            content_type=file_type,
+            sm_hosts=sm_hosts,
+            current_host=sm_current_host,
+            checkpoint_dir=checkpoint_dir,
+            num_gpus=num_gpus,
+        )
     else:
-        raise exc.PlatformError("Number of hosts should be an int greater than or equal to 1")
+        if num_gpus > 1:
+            logging.warning(
+                f"If you're using GPU training, not all GPUs on the instance will be used. "
+                f"See how to use all GPUs at {DOCUMENTATION_LINK}"
+            )
+
+        train_dmatrix, val_dmatrix, train_val_dmatrix = get_validated_dmatrices(
+            train_path, val_path, file_type, csv_weights, is_pipe, combine_train_val
+        )
+        train_args = dict(
+            train_cfg=validated_train_config,
+            train_dmatrix=train_dmatrix,
+            val_dmatrix=val_dmatrix,
+            train_val_dmatrix=train_val_dmatrix,
+            model_dir=model_dir,
+            checkpoint_dir=checkpoint_dir,
+        )
+        if num_hosts > 1:
+            # Wait for hosts to find each other
+            logging.info("Distributed node training with {} hosts: {}".format(num_hosts, sm_hosts))
+            distributed.wait_hostname_resolution(sm_hosts)
+            if not train_dmatrix:
+                logging.warning(
+                    "Host {} does not have data. Will broadcast to cluster and will not be used in distributed"
+                    " training.".format(sm_current_host)
+                )
+            distributed.rabit_run(
+                exec_fun=train_job,
+                args=train_args,
+                include_in_training=(train_dmatrix is not None),
+                hosts=sm_hosts,
+                current_host=sm_current_host,
+                update_rabit_args=True,
+            )
+        elif num_hosts == 1:
+            if train_dmatrix:
+                if validation_channel:
+                    if not val_dmatrix:
+                        raise exc.UserError("No data in validation channel path {}".format(val_path))
+                logging.info("Single node training.")
+                train_args.update({"is_master": True})
+                train_job(**train_args)
+            else:
+                raise exc.UserError("No data in training channel path {}".format(train_path))
+        else:
+            raise exc.PlatformError("Number of hosts should be an int greater than or equal to 1")
 
 
 def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_dir, checkpoint_dir, is_master):
@@ -259,11 +274,12 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
 
     try:
         kfold = train_cfg.pop("_kfold", None)
+        watchlist = [(train_dmatrix, "train")]
+        if val_dmatrix is not None:
+            watchlist.append((val_dmatrix, "validation"))
 
         if kfold is None:
-            xgb_model, iteration, callbacks, watchlist = get_callbacks_watchlist(
-                train_dmatrix=train_dmatrix,
-                val_dmatrix=val_dmatrix,
+            xgb_model, iteration, callbacks = get_callbacks(
                 model_dir=model_dir,
                 checkpoint_dir=checkpoint_dir,
                 early_stopping_data_name=early_stopping_data_name,
@@ -322,9 +338,7 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
                 cv_train_dmatrix = train_val_dmatrix.slice(train_idx)
                 cv_val_dmatrix = train_val_dmatrix.slice(val_idx)
 
-                xgb_model, iteration, callbacks, watchlist = get_callbacks_watchlist(
-                    train_dmatrix=cv_train_dmatrix,
-                    val_dmatrix=cv_val_dmatrix,
+                xgb_model, iteration, callbacks = get_callbacks(
                     model_dir=model_dir,
                     checkpoint_dir=checkpoint_dir,
                     early_stopping_data_name=early_stopping_data_name,
@@ -389,61 +403,6 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
                 model_location = os.path.join(model_dir, f"{MODEL_NAME}-{fold}")
                 bst[fold].save_model(model_location)
                 logging.debug("Stored trained model {} at {}".format(fold, model_location))
-
-
-def get_callbacks_watchlist(
-    train_dmatrix,
-    val_dmatrix,
-    model_dir,
-    checkpoint_dir,
-    early_stopping_data_name,
-    early_stopping_metric,
-    early_stopping_rounds,
-    save_model_on_termination,
-    is_master,
-    fold=None,
-):
-    if checkpoint_dir and fold is not None:
-        checkpoint_dir = os.path.join(checkpoint_dir, f"model-{fold}")
-
-    # Set callbacks
-    xgb_model, iteration = checkpointing.load_checkpoint(checkpoint_dir)
-    if xgb_model is not None:
-        if fold is not None:
-            xgb_model = f"{xgb_model}-{fold}"
-        logging.info("Checkpoint loaded from %s", xgb_model)
-        logging.info("Resuming from iteration %s", iteration)
-
-    callbacks = []
-    callbacks.append(xgb.callback.EvaluationMonitor())
-    if checkpoint_dir:
-        save_checkpoint = xgb.callback.TrainingCheckPoint(
-            directory=checkpoint_dir, iterations=iteration, name=checkpointing.CHECKPOINT_FILENAME
-        )
-        callbacks.append(save_checkpoint)
-
-    if save_model_on_termination == "true":
-        model_name = f"{MODEL_NAME}-{fold}" if fold is not None else MODEL_NAME
-        save_intermediate_model = checkpointing.SaveIntermediateModelCallBack(model_dir, model_name, is_master)
-        callbacks.append(save_intermediate_model)
-        add_sigterm_handler(model_dir, is_master)
-
-    if early_stopping_data_name and early_stopping_metric and early_stopping_rounds:
-        maximize = early_stopping_metric in XGB_MAXIMIZE_METRICS
-        early_stop = xgb.callback.EarlyStopping(
-            rounds=early_stopping_rounds,
-            data_name=early_stopping_data_name,
-            metric_name=early_stopping_metric,
-            maximize=maximize,
-            save_best=True,
-        )
-        callbacks.append(early_stop)
-
-    watchlist = [(train_dmatrix, "train")]
-    if val_dmatrix is not None:
-        watchlist.append((val_dmatrix, "validation"))
-
-    return xgb_model, iteration, callbacks, watchlist
 
 
 def print_cv_metric(num_round, evals_results):

--- a/src/sagemaker_xgboost_container/callback.py
+++ b/src/sagemaker_xgboost_container/callback.py
@@ -1,6 +1,11 @@
 import logging
-
+import os
+import signal
 import xgboost as xgb
+
+from sagemaker_xgboost_container import checkpointing
+from sagemaker_xgboost_container.algorithm_mode import train_utils
+from sagemaker_xgboost_container.constants.xgb_constants import MODEL_NAME, XGB_MAXIMIZE_METRICS
 from smdebug.xgboost import Hook
 
 logger = logging.getLogger(__name__)
@@ -45,3 +50,73 @@ def add_debugging(callbacks, hyperparameters, train_dmatrix, val_dmatrix=None, j
         logging.debug("Failed to create debug hook", e)
     else:
         callbacks.append(hook)
+
+
+def add_sigterm_handler(model_dir, is_master):
+    """Stop training and cleanup model directory when SIGTERM is received.
+
+    Model directory is only cleaned if is_master is True. Otherwise program terminates.
+
+    :param model_dir: Directory where model is saved
+    :param is_master: True if single node training, or the current node is the master node in distributed training
+    """
+
+    def _terminate():
+        os._exit(0)
+
+    def _cleanup_files(signo, frame):
+        if is_master:
+            train_utils.cleanup_dir(model_dir, MODEL_NAME)
+
+        _terminate()
+
+    signal.signal(signal.SIGTERM, _cleanup_files)
+
+
+def get_callbacks(
+    model_dir,
+    checkpoint_dir,
+    early_stopping_data_name,
+    early_stopping_metric,
+    early_stopping_rounds,
+    save_model_on_termination,
+    is_master,
+    fold=None,
+):
+    if checkpoint_dir and fold is not None:
+        checkpoint_dir = os.path.join(checkpoint_dir, f"model-{fold}")
+
+    # Set callbacks
+    xgb_model, iteration = checkpointing.load_checkpoint(checkpoint_dir)
+    if xgb_model is not None:
+        if fold is not None:
+            xgb_model = f"{xgb_model}-{fold}"
+        logging.info("Checkpoint loaded from %s", xgb_model)
+        logging.info("Resuming from iteration %s", iteration)
+
+    callbacks = []
+    callbacks.append(xgb.callback.EvaluationMonitor())
+    if checkpoint_dir:
+        save_checkpoint = xgb.callback.TrainingCheckPoint(
+            directory=checkpoint_dir, iterations=iteration, name=checkpointing.CHECKPOINT_FILENAME
+         )
+        callbacks.append(save_checkpoint)
+
+    if save_model_on_termination == "true":
+        model_name = f"{MODEL_NAME}-{fold}" if fold is not None else MODEL_NAME
+        save_intermediate_model = checkpointing.SaveIntermediateModelCallBack(model_dir, model_name, is_master)
+        callbacks.append(save_intermediate_model)
+        add_sigterm_handler(model_dir, is_master)
+
+    if early_stopping_data_name and early_stopping_metric and early_stopping_rounds:
+        maximize = early_stopping_metric in XGB_MAXIMIZE_METRICS
+        early_stop = xgb.callback.EarlyStopping(
+            rounds=early_stopping_rounds,
+            data_name=early_stopping_data_name,
+            metric_name=early_stopping_metric,
+            maximize=maximize,
+            save_best=True,
+        )
+        callbacks.append(early_stop)
+
+    return xgb_model, iteration, callbacks

--- a/src/sagemaker_xgboost_container/constants/xgb_constants.py
+++ b/src/sagemaker_xgboost_container/constants/xgb_constants.py
@@ -93,3 +93,7 @@ MULTI_SOFTMAX = "multi:softmax"
 MULTI_SOFTPROB = "multi:softprob"
 
 MODEL_NAME = "xgboost-model"
+GPU_TREE_METHOD = "gpu_hist"
+
+FULLY_REPLICATED = "FullyReplicated"
+PIPE_MODE = "Pipe"

--- a/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
+++ b/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
@@ -15,7 +15,7 @@ import os
 
 import dask.dataframe as dask_dataframe
 from dask.dataframe import DataFrame, Series
-from dask.distributed import Client, wait
+from dask.distributed import Client
 from xgboost.dask import DaskDMatrix
 
 from sagemaker_algorithm_toolkit.exceptions import AlgorithmError, UserError

--- a/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
+++ b/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
@@ -22,7 +22,7 @@ from sagemaker_algorithm_toolkit.exceptions import AlgorithmError, UserError
 from sagemaker_xgboost_container.data_utils import CSV, PARQUET
 
 
-def _read_data(local_path: str, content_type: str) -> (DataFrame, Series):
+def read_data(local_path: str, content_type: str) -> (DataFrame, Series):
     if content_type == CSV:
         dataframe = dask_dataframe.read_csv(os.path.join(local_path, "*.csv"), header=None)
     elif content_type == PARQUET:
@@ -43,18 +43,6 @@ def get_dataframe_dimensions(dataframe: DataFrame) -> (int, int):
     rows = df_shape[0].compute()
     cols = df_shape[1]
     return rows, cols
-
-
-def load_data_into_memory(client: Client, local_data_path: str, content_type: str) -> (DataFrame, Series):
-    try:
-        features, labels = _read_data(local_data_path, content_type)
-        # Due to the lazy nature of Dask collections,
-        # most data related errors will likely show up once data load is started here.
-        features, labels = client.persist([features, labels])
-        wait([features, labels])
-    except Exception as e:
-        raise UserError(f"Failed to load data. Exception: {e}")
-    return features, labels
 
 
 def create_dask_dmatrix(client: Client, features: DataFrame, labels: Series) -> DaskDMatrix:

--- a/src/sagemaker_xgboost_container/distributed_gpu/distributed_gpu_training.py
+++ b/src/sagemaker_xgboost_container/distributed_gpu/distributed_gpu_training.py
@@ -38,7 +38,7 @@ from sagemaker_xgboost_container.distributed_gpu.dask_cluster_utils import (
 from sagemaker_xgboost_container.distributed_gpu.dask_data_utils import (
     create_dask_dmatrix,
     get_dataframe_dimensions,
-    load_data_into_memory,
+    read_data,
 )
 
 logger = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ def run_training_with_dask(
             logging.info("Starting to read training data...")
             watchlist = []
 
-            X_train, y_train = load_data_into_memory(client, train_path, content_type)
+            X_train, y_train = read_data(train_path, content_type)
 
             dtrain = create_dask_dmatrix(client, X_train, y_train)
 
@@ -111,7 +111,7 @@ def run_training_with_dask(
 
             dvalid = None
             if validation_path:
-                X_valid, y_valid = load_data_into_memory(client, validation_path, content_type)
+                X_valid, y_valid = read_data(validation_path, content_type)
                 dvalid = create_dask_dmatrix(client, X_valid, y_valid)
                 watchlist.append((dvalid, "validation"))
 

--- a/src/sagemaker_xgboost_container/distributed_gpu/distributed_gpu_training.py
+++ b/src/sagemaker_xgboost_container/distributed_gpu/distributed_gpu_training.py
@@ -21,7 +21,16 @@ import xgboost as xgb
 from dask.distributed import Client
 
 from sagemaker_algorithm_toolkit import exceptions as exc
-from sagemaker_xgboost_container.constants.xgb_constants import MODEL_NAME
+from sagemaker_algorithm_toolkit.channel_validation import S3_DIST_TYPE, Channel
+from sagemaker_algorithm_toolkit.exceptions import UserError
+from sagemaker_xgboost_container.algorithm_mode import train_utils
+from sagemaker_xgboost_container.callback import get_callbacks
+from sagemaker_xgboost_container.constants.xgb_constants import (
+    GPU_TREE_METHOD,
+    MODEL_NAME,
+    PIPE_MODE,
+)
+from sagemaker_xgboost_container.data_utils import CSV, PARQUET
 from sagemaker_xgboost_container.distributed_gpu.dask_cluster_utils import (
     get_host_ip,
     start_daemons_in_current_instance,
@@ -37,6 +46,28 @@ logger = logging.getLogger(__name__)
 SCHEDULER_PORT = "8786"
 WAIT_FOR_ALL_WORKERS_TIMEOUT_SEC = 20
 WORKER_STAY_ALIVE_CHECK_FREQ_SEC = 10
+SUPPORTED_TRAINING_CONTENT_TYPES = {CSV, PARQUET}
+
+NON_GPU_ERROR_MSG = "Dask training is only available for `gpu_hist` training on GPU instances."
+PIPE_MODE_ERROR_MSG = "Dask training is not supported for pipe mode input."
+INPUT_FORMAT_ERROR_MSG = "Dask training is only supported for CSV and Parquet input."
+NOT_REPLICATED_ERROR_MSG = "Dask distributed training requires FullyReplicated data."
+
+
+def check_if_all_conditions_met(
+    tree_method_hp: str, num_hosts: int, num_gpus: int, input_mode: str, input_format: str, data_config: Dict
+):
+    if tree_method_hp != GPU_TREE_METHOD or num_gpus == 0:
+        raise UserError(NON_GPU_ERROR_MSG)
+    if input_mode == PIPE_MODE:
+        raise UserError(PIPE_MODE_ERROR_MSG)
+    if input_format not in SUPPORTED_TRAINING_CONTENT_TYPES:
+        raise UserError(INPUT_FORMAT_ERROR_MSG)
+    is_channels_not_replicated = any(
+        {channel.get(S3_DIST_TYPE, None) != Channel.REPLICATED for channel in data_config.values()}
+    )
+    if is_channels_not_replicated and num_hosts > 1:
+        raise UserError(NOT_REPLICATED_ERROR_MSG)
 
 
 def run_training_with_dask(
@@ -47,14 +78,14 @@ def run_training_with_dask(
     content_type: str,
     sm_hosts: [str],
     current_host: str,
+    checkpoint_dir: str,
     num_gpus: int,
 ):
     scheduler_host = sm_hosts[0]
+    is_scheduler_host = current_host == scheduler_host
     scheduler_host_ip = get_host_ip(scheduler_host)
 
     scheduler_address = f"{scheduler_host_ip}:{SCHEDULER_PORT}"
-    is_scheduler_host = current_host == scheduler_host
-
     start_daemons_in_current_instance(scheduler_address, is_scheduler_host)
 
     total_num_workers = len(sm_hosts) * num_gpus
@@ -78,16 +109,63 @@ def run_training_with_dask(
 
             watchlist.append((dtrain, "train"))
 
-            if validation_path is not None:
+            dvalid = None
+            if validation_path:
                 X_valid, y_valid = load_data_into_memory(client, validation_path, content_type)
                 dvalid = create_dask_dmatrix(client, X_valid, y_valid)
                 watchlist.append((dvalid, "validation"))
 
             logging.info("Data load complete. Starting training...")
 
+            # Redundant Code -------------------------------------------------------------------- >
+            """
+            The blob below is the redundant code we can see in the original training flow. Some
+            points that might be worth addressing in the copied blob below are as follows:
+            * Are hardcoded static string references everywhere really the best way to do this?
+            * Can we consolidate this data cleanup and popping business into an appropriate class?
+            * Similar to the above point, is an anemic data model/similar an angle worth considering?
+            * Do we have overhead concerns with the debugging if we need to convert to DMatrix?
+            * Does allowing for cross validation outweigh overhead concerns between CPU & GPU?
+            """
+            num_round = hyperparameters.pop("num_round")
+            save_model_on_termination = hyperparameters.pop("save_model_on_termination", "false")
+            tuning_objective_metric_param = hyperparameters.pop("_tuning_objective_metric", None)
+            eval_metric = hyperparameters.pop("eval_metric", None)
+            cleaned_eval_metric, configured_feval, tuning_objective_metric = train_utils.get_eval_metrics_and_feval(
+                tuning_objective_metric_param, eval_metric
+            )
+            if cleaned_eval_metric:
+                hyperparameters["eval_metric"] = cleaned_eval_metric
+
+            early_stopping_data_name = "validation" if dvalid else None
+            early_stopping_rounds = hyperparameters.pop("early_stopping_rounds", None)
+
+            early_stopping_metric = None
+            if early_stopping_rounds:
+                if tuning_objective_metric:
+                    early_stopping_metric = tuning_objective_metric[-1]
+                elif eval_metric:
+                    early_stopping_metric = eval_metric[-1]
+
+            xgb_model, iteration, callbacks = get_callbacks(
+                model_dir=model_dir,
+                checkpoint_dir=checkpoint_dir,
+                early_stopping_data_name=early_stopping_data_name,
+                early_stopping_metric=early_stopping_metric,
+                early_stopping_rounds=early_stopping_rounds,
+                save_model_on_termination=save_model_on_termination,
+                is_master=is_scheduler_host,
+            )
+
             try:
                 output = xgb.dask.train(
-                    client, hyperparameters, dtrain, num_boost_round=hyperparameters["num_round"], evals=watchlist
+                    client=client,
+                    params=hyperparameters,
+                    dtrain=dtrain,
+                    num_boost_round=num_round,
+                    evals=watchlist,
+                    feval=configured_feval,
+                    callbacks=callbacks,
                 )
                 booster = output["booster"]
 

--- a/test/unit/distributed_gpu/test_dask_data_utils.py
+++ b/test/unit/distributed_gpu/test_dask_data_utils.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from sagemaker_algorithm_toolkit.exceptions import UserError
 from sagemaker_xgboost_container.data_utils import CSV, LIBSVM, PARQUET
-from sagemaker_xgboost_container.distributed_gpu.dask_data_utils import _read_data
+from sagemaker_xgboost_container.distributed_gpu.dask_data_utils import read_data
 
 
 class TestDaskDataUtils(unittest.TestCase):
@@ -37,25 +37,25 @@ class TestDaskDataUtils(unittest.TestCase):
         )
 
     def test_read_data_csv(self):
-        x, y = _read_data(self.data_path_csv, CSV)
+        x, y = read_data(self.data_path_csv, CSV)
         assert x.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE
         assert x.shape[1] == self.NUM_COLS_IN_EACH_FILE - 1
         assert y.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE
 
     def test_read_data_csv_malformed_path(self):
-        x, y = _read_data(self.data_path_csv + "/", CSV)
+        x, y = read_data(self.data_path_csv + "/", CSV)
         assert x.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE
 
     def test_read_data_csv_multiple_files(self):
-        x, y = _read_data(self.data_path_csv_multiple, CSV)
+        x, y = read_data(self.data_path_csv_multiple, CSV)
         assert x.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE * 2
 
     def test_read_data_parquet(self):
-        x, y = _read_data(self.data_path_parquet, PARQUET)
+        x, y = read_data(self.data_path_parquet, PARQUET)
         assert x.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE * 2
         assert x.shape[1] == self.NUM_COLS_IN_EACH_FILE - 1
         assert y.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE * 2
 
     def test_read_data_unsupported_content(self):
         with self.assertRaises(UserError):
-            _read_data(self.data_path_parquet, LIBSVM)
+            read_data(self.data_path_parquet, LIBSVM)

--- a/test/unit/distributed_gpu/test_distributed_gpu_training.py
+++ b/test/unit/distributed_gpu/test_distributed_gpu_training.py
@@ -1,0 +1,65 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import unittest
+
+from sagemaker_algorithm_toolkit import channel_validation as cv
+from sagemaker_algorithm_toolkit.exceptions import UserError
+from sagemaker_xgboost_container.distributed_gpu.distributed_gpu_training import (
+    INPUT_FORMAT_ERROR_MSG,
+    NON_GPU_ERROR_MSG,
+    NOT_REPLICATED_ERROR_MSG,
+    PIPE_MODE_ERROR_MSG,
+    check_if_all_conditions_met,
+)
+
+
+class TestDistributedGPUTraining(unittest.TestCase):
+    def setUp(self):
+        self.train_channel_replicated = {"train": {cv.S3_DIST_TYPE: "FullyReplicated"}}
+        self.train_channel_not_replicated = {"train": {cv.S3_DIST_TYPE: "ShardedByS3Key"}}
+        self.multi_channel_not_replicated = {
+            "train": {cv.S3_DIST_TYPE: "FullyReplicated"},
+            "valid": {cv.S3_DIST_TYPE: "ShardedByS3Key"},
+        }
+
+    def test_conditions_fail_channel_not_replicated_multi_host(self):
+        with self.assertRaises(UserError) as e:
+            check_if_all_conditions_met("gpu_hist", 2, 1, "File", "csv", self.multi_channel_not_replicated)
+            assert e.exception == NOT_REPLICATED_ERROR_MSG
+
+    def test_conditions_pass_channel_replicated_multi_host(self):
+        check_if_all_conditions_met("gpu_hist", 2, 1, "File", "csv", self.train_channel_replicated)
+
+    def test_conditions_pass_channel_not_replicated_singlehost(self):
+        check_if_all_conditions_met("gpu_hist", 1, 1, "File", "csv", self.train_channel_not_replicated)
+
+    def test_conditions_fail_not_gpu_instance(self):
+        with self.assertRaises(UserError) as e:
+            check_if_all_conditions_met("gpu_hist", 1, 0, "File", "csv", self.train_channel_replicated)
+            assert e.exception == NON_GPU_ERROR_MSG
+
+    def test_conditions_fail_non_gpu_tree_method(self):
+        with self.assertRaises(UserError) as e:
+            check_if_all_conditions_met("approx", 1, 1, "File", "csv", self.train_channel_replicated)
+            assert e.exception == NON_GPU_ERROR_MSG
+
+    def test_conditions_fail_pipe_mode(self):
+        with self.assertRaises(UserError) as e:
+            check_if_all_conditions_met("gpu_hist", 1, 1, "Pipe", "csv", self.train_channel_replicated)
+            assert e.exception == PIPE_MODE_ERROR_MSG
+
+    def test_conditions_fail_unsupported_format(self):
+        with self.assertRaises(UserError) as e:
+            check_if_all_conditions_met("gpu_hist", 1, 1, "File", "libsvm", self.train_channel_replicated)
+            assert e.exception == INPUT_FORMAT_ERROR_MSG


### PR DESCRIPTION
This builds on top of the dask branch. The changes here are adding Dask training call to algorithm mode:
* Adding early stopping and custom metric support to Dask training.
* Adding a HP `use_dask_gpu_training ` for customers to trigger training with Dask.
* Validations to check training config is suitable for Dask. Show relevant messages otherwise.
* As commented in the code, some code blocks are duplicates and will be reworked later, due to time constraints atm.
* Removed explicit data loading in the cluster, as I saw about 15% more peak memory usage, compared to when letting the underlying DaskDMatrix code load the data. The only downside I can think of is possibly confusing error message if there are any data load failures.
* Note that custom metric(feval) arg increases the training time by considerable amount for training with large data. It's used when `eval_metric` is specified by the user or tuning metric is specified for HPO. Looking at the underlying code it deals with DMatrix directly, which could be the reason for the slowdown. It doesn't look like we're doing anything wrong.

*Testing:*
* Ran unit tests.
* Ran integ tests to confirm current code flow is uneffected.
* Ran notebook training test with Dask flag, and also with early stopping rounds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
