### PR TITLE
Bump smdebug version to 1.0.29

### DIFF
--- a/docker/1.5-1/final/Dockerfile.cpu
+++ b/docker/1.5-1/final/Dockerfile.cpu
@@ -9,8 +9,10 @@ ARG SAGEMAKER_XGBOOST_VERSION
 # Install dependencies #
 ########################
 COPY requirements.txt /requirements.txt
-RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt && \
-    python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
+RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
+
+# Install smdebug from source
+RUN python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
 
 
 ###########################

--- a/docker/1.5-1/final/Dockerfile.cpu
+++ b/docker/1.5-1/final/Dockerfile.cpu
@@ -12,7 +12,7 @@ COPY requirements.txt /requirements.txt
 RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 
 # Install smdebug from source
-RUN python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
+RUN python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.29
 
 
 ###########################

--- a/docker/1.5-1/final/Dockerfile.cpu
+++ b/docker/1.5-1/final/Dockerfile.cpu
@@ -10,7 +10,7 @@ ARG SAGEMAKER_XGBOOST_VERSION
 ########################
 COPY requirements.txt /requirements.txt
 RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt && \
-python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
+    python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
 
 
 ###########################

--- a/docker/1.5-1/final/Dockerfile.cpu
+++ b/docker/1.5-1/final/Dockerfile.cpu
@@ -9,7 +9,9 @@ ARG SAGEMAKER_XGBOOST_VERSION
 # Install dependencies #
 ########################
 COPY requirements.txt /requirements.txt
-RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
+RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt && \
+python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
+
 
 ###########################
 # Copy wheel to container #

--- a/docker/1.5-1/final/Dockerfile_arm64.cpu
+++ b/docker/1.5-1/final/Dockerfile_arm64.cpu
@@ -10,6 +10,7 @@ ARG SAGEMAKER_XGBOOST_VERSION
 ########################
 COPY requirements.txt /requirements.txt
 RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
+python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
 
 ###########################
 # Copy wheel to container #

--- a/docker/1.5-1/final/Dockerfile_arm64.cpu
+++ b/docker/1.5-1/final/Dockerfile_arm64.cpu
@@ -9,8 +9,8 @@ ARG SAGEMAKER_XGBOOST_VERSION
 # Install dependencies #
 ########################
 COPY requirements.txt /requirements.txt
-RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
-python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
+RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt && \
+    python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
 
 ###########################
 # Copy wheel to container #

--- a/docker/1.5-1/final/Dockerfile_arm64.cpu
+++ b/docker/1.5-1/final/Dockerfile_arm64.cpu
@@ -12,7 +12,7 @@ COPY requirements.txt /requirements.txt
 RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
 
 # Install smdebug from source
-RUN python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
+RUN python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.29
 
 ###########################
 # Copy wheel to container #

--- a/docker/1.5-1/final/Dockerfile_arm64.cpu
+++ b/docker/1.5-1/final/Dockerfile_arm64.cpu
@@ -9,8 +9,10 @@ ARG SAGEMAKER_XGBOOST_VERSION
 # Install dependencies #
 ########################
 COPY requirements.txt /requirements.txt
-RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt && \
-    python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
+RUN python3 -m pip install -r /requirements.txt && rm /requirements.txt
+
+# Install smdebug from source
+RUN python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git@1.0.28
 
 ###########################
 # Copy wheel to container #

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.5.5
 scikit-learn==0.24.1
 scipy==1.6.2
-smdebug==1.0.10
 urllib3==1.26.5
 wheel==0.36.2
 jinja2==2.11.3

--- a/src/sagemaker_xgboost_container/callback.py
+++ b/src/sagemaker_xgboost_container/callback.py
@@ -11,27 +11,6 @@ from smdebug.xgboost import Hook
 logger = logging.getLogger(__name__)
 
 
-class SmeDebugHook(xgb.callback.TrainingCallback, Hook):
-    """Mix-in callback class. smedebug.xgboost.Hook uses legacy callback style
-    and since XGB-3.0.0 mixing legacy callback instances with new TrainingCallback
-    instances is not allowed.
-
-    See: https://github.com/dmlc/xgboost/blob/v1.3.0/python-package/xgboost/training.py#L92-L93
-
-    :param hyperparameters: Dict of hyperparamters.
-                            Same as `params` in xgb.train(params, dtrain).
-    :param train_dmatrix: Training data set.
-    :param val_dmatrix: Validation data set.
-    """
-
-    def __init__(self, json_config_path, hyperparameters, train_dmatrix, val_dmatrix):
-        self = self.hook_from_config(json_config_path)
-        self.hyperparameters = hyperparameters
-        self.train_data = train_dmatrix
-        if val_dmatrix is not None:
-            self.validation_data = val_dmatrix
-
-
 def add_debugging(callbacks, hyperparameters, train_dmatrix, val_dmatrix=None, json_config_path=None):
     """Add a sagemaker debug hook to a list of callbacks.
 
@@ -44,12 +23,16 @@ def add_debugging(callbacks, hyperparameters, train_dmatrix, val_dmatrix=None, j
                              instead of default config file.
     """
     try:
-        hook = SmeDebugHook(json_config_path, hyperparameters, train_dmatrix, val_dmatrix)
+        hook = Hook.hook_from_config(json_config_path)
+        hook.hyperparameters = hyperparameters
+        hook.train_data = train_dmatrix
+        if val_dmatrix is not None:
+            hook.validation_data = val_dmatrix
+        callbacks.append(hook)
         logging.info("Debug hook created from config")
     except Exception as e:
         logging.debug("Failed to create debug hook", e)
-    else:
-        callbacks.append(hook)
+        return
 
 
 def add_sigterm_handler(model_dir, is_master):

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -26,6 +26,7 @@ sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.5.5
 scikit-learn==0.24.1
 scipy==1.6.2
+smdebug==1.0.28
 urllib3==1.26.5
 wheel==0.36.2
 jinja2==2.11.3
@@ -41,6 +42,13 @@ def assert_python_version(major, minor):
 def assert_package_version(package_name, version):
     installed_version = pkg_resources.get_distribution(package_name).version
     error_message = f"{package_name} requires {version} but {installed_version} is installed."
+    # As smdebug is being installed from source its setup.py
+    # it appends the character 'b' and the installation date to the version
+    # https://github.com/awslabs/sagemaker-debugger/blob/master/setup.py#L97
+    if package_name == "smdebug":
+        assert version == installed_version.split('b')[0], error_message
+    else:
+        assert version == installed_version, error_message
     assert version == installed_version, error_message
 
 

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -26,7 +26,7 @@ sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.5.5
 scikit-learn==0.24.1
 scipy==1.6.2
-smdebug==1.0.28
+smdebug==1.0.29
 urllib3==1.26.5
 wheel==0.36.2
 jinja2==2.11.3
@@ -42,13 +42,7 @@ def assert_python_version(major, minor):
 def assert_package_version(package_name, version):
     installed_version = pkg_resources.get_distribution(package_name).version
     error_message = f"{package_name} requires {version} but {installed_version} is installed."
-    # As smdebug is being installed from source its setup.py
-    # it appends the character 'b' and the installation date to the version
-    # https://github.com/awslabs/sagemaker-debugger/blob/master/setup.py#L97
-    if package_name == "smdebug":
-        assert version == installed_version.split('b')[0], error_message
-    else:
-        assert version == installed_version, error_message
+    assert version == installed_version, error_message
 
 
 def parse_requirements(requirements):

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -26,7 +26,6 @@ sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.5.5
 scikit-learn==0.24.1
 scipy==1.6.2
-smdebug==1.0.10
 urllib3==1.26.5
 wheel==0.36.2
 jinja2==2.11.3

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -49,7 +49,6 @@ def assert_package_version(package_name, version):
         assert version == installed_version.split('b')[0], error_message
     else:
         assert version == installed_version, error_message
-    assert version == installed_version, error_message
 
 
 def parse_requirements(requirements):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Debugger team released a fix for supporting XgBoost report and other debugger functionality for XgBoost version 1.3 and beyond - https://github.com/awslabs/sagemaker-debugger/pull/648
- Bumping the version of smdebug to 1.0.29 to patch the fix in XgBoost container 1.5-1
- Made related changes to support the new smdebug version
- Related PR - https://github.com/awslabs/sagemaker-debugger/pull/650

*Testing:*
- Unit test
- Flake8
- Integration tests
- Tested notebook with the updated image https://github.com/aws/amazon-sagemaker-examples/blob/main/sagemaker-debugger/xgboost_training_report/higgs_boson_detection.ipynb


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
