### PR TITLE
Fix dask-cuda dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ numpy==1.19.2
 pandas==1.2.4
 protobuf==3.20.1
 psutil==5.6.7  # sagemaker-containers requires psutil 5.6.7
+pynvml==11.4.1
 python-dateutil==2.8.1
 requests==2.25.1
 retrying==1.3.3


### PR DESCRIPTION
The newly released version of pynvml(a dependency of dask cuda), contains a breaking change. Fixing the older version for now. See https://github.com/dask/distributed/pull/7544 

*Testing:*
* Ran integ test with image from this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
