### PR TITLE
Updating module import function from modules to importlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyYAML==5.4.1
 Pillow==9.1.1
 boto3==1.17.52
 botocore==1.20.52
-cryptography==35.0.0
+cryptography==39.0.1
 dask==2022.11.1
 dask-cuda==22.12.0
 gunicorn==19.10.0

--- a/src/sagemaker_xgboost_container/serving.py
+++ b/src/sagemaker_xgboost_container/serving.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import logging
 import os
+import importlib
 
 from sagemaker_containers.beta.framework import (
     encoders,
@@ -144,7 +145,7 @@ def main(environ, start_response):
         if serving_env.module_name is None:
             app = serve.ScoringService.csdk_start()
         else:
-            user_module = modules.import_module(serving_env.module_dir, serving_env.module_name)
+            user_module = importlib.import_module(serving_env.module_name)
             user_module_transformer = _user_module_transformer(user_module)
             user_module_transformer.initialize()
             app = worker.Worker(

--- a/src/sagemaker_xgboost_container/serving.py
+++ b/src/sagemaker_xgboost_container/serving.py
@@ -19,7 +19,6 @@ import importlib
 from sagemaker_containers.beta.framework import (
     encoders,
     env,
-    modules,
     server,
     transformer,
     worker,


### PR DESCRIPTION
*Description of changes:*
This change addresses an issue where, by use of `modules`, every worker invoked installs the module. Switching to `importlib` then reduces this to a single install.

*Testing:*
Gamma tests succeeded against the new image. In one integration test using the current image, the logs reveal the issue with multiple lines of ` /miniconda3/bin/python3 -m pip install .` With the new image built from these changes, we see only a single line of ` /miniconda3/bin/python3 -m pip install .`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
