### PR TITLE
Addressing NCCL issue with binary classification for distributed training

### DIFF
--- a/docker/1.7-1/final/Dockerfile.cpu
+++ b/docker/1.7-1/final/Dockerfile.cpu
@@ -69,6 +69,9 @@ ENV SM_INPUT /opt/ml/input
 ENV SM_INPUT_TRAINING_CONFIG_FILE $SM_INPUT/config/hyperparameters.json
 ENV SM_INPUT_DATA_CONFIG_FILE $SM_INPUT/config/inputdataconfig.json
 ENV SM_CHECKPOINT_CONFIG_FILE $SM_INPUT/config/checkpointconfig.json
+# See: https://github.com/dmlc/xgboost/issues/7982#issuecomment-1379390906 https://github.com/dmlc/xgboost/pull/8257
+ENV NCCL_SOCKET_IFNAME eth 
+                            
 
 # Set SageMaker serving environment variables
 ENV SM_MODEL_DIR /opt/ml/model


### PR DESCRIPTION


https://github.com/dmlc/xgboost/issues/7982#issuecomment-1379390906 https://github.com/dmlc/xgboost/pull/8257

*Issue #, if available:*
XGBoost-1.7 introduced a [braking change](https://github.com/dmlc/xgboost/pull/8257) that introduced issue with NCCL. To address the issue, we need to set the NCCL_SOCKET_IFNAME env. variable  
*Description of changes:*
set NCCL_SOCKET_IFNAME
*Testing:*
Created a test image: 900597767885.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:nikhil-test
And tested the image, it is not throwing an error anymore for binary classification. (arn:aws:sagemaker:us-west-2:900597767885:training-job/sagemaker-xgboost-2023-03-17-14-36-52-062)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
