### PR TITLE
Fix the distribute CPU training error when validation data can't be well divided

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -198,6 +198,9 @@ def sagemaker_train(
         train_dmatrix, val_dmatrix, train_val_dmatrix = get_validated_dmatrices(
             train_path, val_path, file_type, csv_weights, is_pipe, combine_train_val
         )
+
+        missing_validation_data = validation_channel and not val_dmatrix
+
         train_args = dict(
             train_cfg=validated_train_config,
             train_dmatrix=train_dmatrix,
@@ -210,22 +213,34 @@ def sagemaker_train(
             # Wait for hosts to find each other
             logging.info(f"Distributed node training with {num_hosts} hosts: {sm_hosts}")
             distributed.wait_hostname_resolution(sm_hosts)
+            include_in_training = True
             if not train_dmatrix:
                 logging.warning(
-                    "Host {} does not have data. Will broadcast to cluster and will not be used in distributed"
-                    " training.".format(sm_current_host)
+                    f"Host {sm_current_host} does not have training data. Will broadcast to cluster and this host {sm_current_host} "
+                    f"will not be used in distributed training. Please divide the training data across instances properly. "
+                    f"See https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost.html#Instance-XGBoost-distributed-training-divide-data. "
                 )
+                include_in_training = False
+            elif missing_validation_data:
+                logging.warning(
+                    f"Host {sm_current_host} does not have validation data in the validation channel : {validation_channel}. "
+                    f"Will broadcast to cluster and this host {sm_current_host}  will not be used in distributed training. "
+                    f"Please divide the training data across instances properly. "
+                    f"See https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost.html#Instance-XGBoost-distributed-training-divide-data. "
+                )
+                include_in_training = False
+
             distributed.rabit_run(
                 exec_fun=train_job,
                 args=train_args,
-                include_in_training=(train_dmatrix is not None),
+                include_in_training=include_in_training,
                 hosts=sm_hosts,
                 current_host=sm_current_host,
                 update_rabit_args=True,
             )
         elif num_hosts == 1:
             if train_dmatrix:
-                if validation_channel and not val_dmatrix:
+                if missing_validation_data:
                     raise exc.UserError(f"No data in validation channel path {val_path}")
                 logging.info("Single node training.")
                 train_args.update({"is_master": True})
@@ -277,6 +292,8 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
     logging.info(f"Train matrix has {train_dmatrix.num_row()} rows and {train_dmatrix.num_col()} columns")
     if val_dmatrix:
         logging.info(f"Validation matrix has {val_dmatrix.num_row()} rows")
+    else:
+        logging.info("No validation data is collected for this training job.")
 
     try:
         kfold = train_cfg.pop("_kfold", None)

--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -216,17 +216,20 @@ def sagemaker_train(
             include_in_training = True
             if not train_dmatrix:
                 logging.warning(
-                    f"Host {sm_current_host} does not have training data. Will broadcast to cluster and this host {sm_current_host} "
-                    f"will not be used in distributed training. Please divide the training data across instances properly. "
-                    f"See https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost.html#Instance-XGBoost-distributed-training-divide-data. "
+                    f"Host {sm_current_host} does not have training data. Will broadcast to "
+                    f"cluster and this host {sm_current_host} will not be used in distributed training. "
+                    f"Please divide the training data across instances properly. See https://docs.aws.amazon.com/"
+                    f"sagemaker/latest/dg/xgboost.html#Instance-XGBoost-distributed-training-divide-data. "
                 )
                 include_in_training = False
-            elif missing_validation_data:
+            if missing_validation_data:
                 logging.warning(
-                    f"Host {sm_current_host} does not have validation data in the validation channel : {validation_channel}. "
-                    f"Will broadcast to cluster and this host {sm_current_host}  will not be used in distributed training. "
-                    f"Please divide the training data across instances properly. "
-                    f"See https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost.html#Instance-XGBoost-distributed-training-divide-data. "
+                    f"Host {sm_current_host} does not have validation data "
+                    f"in the validation channel : {validation_channel}. "
+                    f"Will broadcast to cluster and this host {sm_current_host} will not be used "
+                    f"in distributed training. Please divide the training data across instances properly. "
+                    f"See https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost.html"
+                    f"#Instance-XGBoost-distributed-training-divide-data. "
                 )
                 include_in_training = False
 

--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -227,7 +227,7 @@ def sagemaker_train(
                     f"Host {sm_current_host} does not have validation data "
                     f"in the validation channel : {validation_channel}. "
                     f"Will broadcast to cluster and this host {sm_current_host} will not be used "
-                    f"in distributed training. Please divide the training data across instances properly. "
+                    f"in distributed training. Please divide the validation data across instances properly. "
                     f"See https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost.html"
                     f"#Instance-XGBoost-distributed-training-divide-data. "
                 )
@@ -295,8 +295,6 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
     logging.info(f"Train matrix has {train_dmatrix.num_row()} rows and {train_dmatrix.num_col()} columns")
     if val_dmatrix:
         logging.info(f"Validation matrix has {val_dmatrix.num_row()} rows")
-    else:
-        logging.info("No validation data is collected for this training job.")
 
     try:
         kfold = train_cfg.pop("_kfold", None)

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -21,6 +21,7 @@ from sklearn.metrics import (
     r2_score,
     recall_score,
 )
+import logging
 
 
 # From 1.2, custom evaluation metric receives raw prediction.
@@ -133,6 +134,8 @@ def rmse(preds, dtrain):
     :return: Metric name, root mean squared error
     """
     labels = dtrain.get_label()
+    logging.info(f"Here's the labels: {labels}")
+    logging.info(f"Here's the preds {preds}")
     return "rmse", mean_squared_error(labels, preds, squared=False)
 
 

--- a/src/sagemaker_xgboost_container/metrics/custom_metrics.py
+++ b/src/sagemaker_xgboost_container/metrics/custom_metrics.py
@@ -21,7 +21,6 @@ from sklearn.metrics import (
     r2_score,
     recall_score,
 )
-import logging
 
 
 # From 1.2, custom evaluation metric receives raw prediction.
@@ -134,8 +133,6 @@ def rmse(preds, dtrain):
     :return: Metric name, root mean squared error
     """
     labels = dtrain.get_label()
-    logging.info(f"Here's the labels: {labels}")
-    logging.info(f"Here's the preds {preds}")
     return "rmse", mean_squared_error(labels, preds, squared=False)
 
 


### PR DESCRIPTION
*Issue #, if available:*
tt: V933345598
*Description of changes:*

Here's the doc about the requirements on input data for Distributed CPU training:
https://docs.aws.amazon.com/sagemaker/latest/dg/xgboost.html#Instance-XGBoost-distributed-training-cpu

We already have the logic to exclude instances from training when they don't have training data.
Let's say, 5 files of training data but customer launched 6 instances so that the one instance without training data will be excluded from this distributed training job.

This change is to add the same logic for validation data when validation channel is already set by customer. The error happens when some instances have validation data but some don't. This will crash the eval metric calculation and MapReduce process across all instances. With this change the above failing scenario will be handled.

*Testing:*

Tested with customer notebook
All references can be found in tt: V933345598


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
