### PR TITLE
fix: train with no validation data

### DIFF
--- a/src/sagemaker_xgboost_container/algorithm_mode/train.py
+++ b/src/sagemaker_xgboost_container/algorithm_mode/train.py
@@ -431,8 +431,10 @@ def train_job(train_cfg, train_dmatrix, val_dmatrix, train_val_dmatrix, model_di
 
 def print_cv_metric(num_round, evals_results):
     cv_eval_report = f"[{num_round}]"
-    for metric_name in evals_results[0]["train"]:
-        for data_name in ["train", "validation"]:
+    data_names = evals_results[0].keys()
+    metric_names = evals_results[0]["train"].keys()
+    for metric_name in metric_names:
+        for data_name in data_names:
             metric_val = [evals_result[data_name][metric_name][-1] for evals_result in evals_results]
             cv_eval_report += f"\t{data_name}-{metric_name}:{np.mean(metric_val):.5f}"
     print(cv_eval_report)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 Flask==1.1.1  # sagemaker-containers requires flask 1.1.1
 black
 coverage
+docker==6.1.3 # docker 7.0.0 has a breaking change: https://github.com/docker/docker-py/issues/3194#issuecomment-1848950456
 docker-compose
 flake8
 isort

--- a/test/unit/algorithm_mode/test_algorithm_mode.py
+++ b/test/unit/algorithm_mode/test_algorithm_mode.py
@@ -238,6 +238,7 @@ class TestAlgorithmModeChannels(unittest.TestCase):
         cs = cv.initialize()
         cs.validate(input_data_config)
 
+
 class TestAlgorithmModeMetrics(unittest.TestCase):
     def setUp(self):
         self.training_environment = basic_training_environment()

--- a/test/unit/algorithm_mode/test_algorithm_mode.py
+++ b/test/unit/algorithm_mode/test_algorithm_mode.py
@@ -226,6 +226,17 @@ class TestAlgorithmModeChannels(unittest.TestCase):
         cs = cv.initialize()
         cs.validate(input_data_config)
 
+    def test_channels_train_only(self):
+        input_data_config = {
+            "train": {
+                "ContentType": "csv",
+                "TrainingInputMode": "File",
+                "S3DistributionType": "FullyReplicated",
+                "RecordWrapperType": "None",
+            },
+        }
+        cs = cv.initialize()
+        cs.validate(input_data_config)
 
 class TestAlgorithmModeMetrics(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
tt: https://t.corp.amazon.com/D102639001/overview

*Issue #, if available:*

*Description of changes:*
With [PR#398](https://github.com/aws/sagemaker-xgboost-container/pull/398), `validation` channel is no longer required to run training in algorithm mode.

There is a regression as `print_cv_metric` uses hardcoded key values that look for both `train` and `validation` channels. This fix uses keys look up in order to print cross-validation metrics instead of hard-coded keys. The fix adds a unit test to prevent such regressions.


*Testing:*
1. Reproduced the issue on XGBoost [1.5-1](https://maxis-file-service-prod-pdx.pdx.proxy.amazon.com/issues/SMAlgo-8864/attachments/854c839db03fedcd26b1ad2c29febf8ceb42863fb0596c025fd89d70f555adaf_635e57d3-6a76-4972-a615-dc6ad8e803c9) and [1.7-1](https://maxis-service-prod-pdx.amazon.com/issues/cae04b3d-4427-4344-9338-4188b82ae2d5/attachments/548420363cde55d4f5075b4aa50c0c665cb5fb78e5a1283268b8da7d5afb965b_410c087e-2719-45ca-8dca-fe4d4077e87b) in eu-west-1 (issue location) using sample datasets from [xgboost_abalone.ipynb](https://github.com/aws/amazon-sagemaker-examples/blob/main/introduction_to_amazon_algorithms/xgboost_abalone/xgboost_abalone.ipynb).
2. Built a docker image with the fix for 1.7-1 and pushed to 900597767885.dkr.ecr.eu-west-1.amazonaws.com/jinyolim-test:1.7-1-cpu-py3-train-only-channel-fix.
3. Used the image with this fix in the same notebook instance environment to verify the fix ([notebook](https://maxis-service-prod-pdx.amazon.com/issues/cae04b3d-4427-4344-9338-4188b82ae2d5/attachments/32701d63c86f437e31ae621ea7d0607a69608538fddcae932fd7f85f2392363e_e10536ea-400d-4277-89c0-c82b9fa51d9a)).




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
