### PR TITLE
upgrade python to 3.9

### DIFF
--- a/docker/1.7-1/base/Dockerfile.cpu
+++ b/docker/1.7-1/base/Dockerfile.cpu
@@ -4,11 +4,11 @@ ARG IMAGE_DIGEST=c2d95c9c6ff77da41cf0f2f9e8c5088f5b4db20c16a7566b808762f05b9032e
 
 FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu${UBUNTU_VERSION}@sha256:${IMAGE_DIGEST}
 
-ARG MINICONDA_VERSION=4.9.2
+ARG MINICONDA_VERSION=24.7.1
+ARG CONDA_CHECKSUM=2006a61abc8b4fd04de5eb92620e1f72bada713cc84b5b4899463095e1210556
 ARG CONDA_PY_VERSION=39
-ARG CONDA_CHECKSUM="b4e46fcc8029e2cfa731b788f25b1d36"
-ARG CONDA_PKG_VERSION=4.10.1
-ARG PYTHON_VERSION=3.8.19
+ARG CONDA_PKG_VERSION=24.7.1
+ARG PYTHON_VERSION=3.9
 ARG PYARROW_VERSION=14.0.1
 ARG MLIO_VERSION=0.9.0
 ARG XGBOOST_VERSION=1.7.4
@@ -80,8 +80,8 @@ RUN apt-key del 7fa2af80 && \
 
 # Install conda
 RUN cd /tmp && \
-    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-py${CONDA_PY_VERSION}_${MINICONDA_VERSION}-Linux-x86_64.sh && \
-    echo "${CONDA_CHECKSUM} /tmp/Miniconda3.sh" | md5sum -c - && \
+    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-py${CONDA_PY_VERSION}_${MINICONDA_VERSION}-0-Linux-x86_64.sh && \
+    echo "${CONDA_CHECKSUM} /tmp/Miniconda3.sh" | sha256sum -c - && \
     bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
     rm /tmp/Miniconda3.sh
 
@@ -96,11 +96,11 @@ RUN echo "conda ${CONDA_PKG_VERSION}" >> /miniconda3/conda-meta/pinned && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
     echo "python ${PYTHON_VERSION}.*" >> /miniconda3/conda-meta/pinned && \
-    conda install -c conda-forge python=${PYTHON_VERSION} && \
+    conda install -c conda-forge python=${PYTHON_VERSION} --solver classic && \
     pip install requests==2.27.0 && \
-    conda install conda=${CONDA_PKG_VERSION} && \
+    conda install conda=${CONDA_PKG_VERSION} --solver classic  && \
     conda update -y conda && \
-    conda install -c conda-forge pyarrow=${PYARROW_VERSION} && \
+    conda install -c conda-forge pyarrow=${PYARROW_VERSION} --solver classic && \
     cd /tmp && \
     git clone --branch v${MLIO_VERSION} https://github.com/awslabs/ml-io.git mlio && \
     cd mlio && \

--- a/docker/1.7-1/final/Dockerfile.cpu
+++ b/docker/1.7-1/final/Dockerfile.cpu
@@ -1,5 +1,5 @@
 ARG SAGEMAKER_XGBOOST_VERSION=1.7-1
-ARG PYTHON_VERSION=3.8
+ARG PYTHON_VERSION=3.9
 
 FROM xgboost-container-base:${SAGEMAKER_XGBOOST_VERSION}-cpu-py3
 
@@ -19,7 +19,7 @@ RUN python3 -m pip install git+https://github.com/awslabs/sagemaker-debugger.git
 # Copy wheel to container #
 ###########################
 COPY dist/sagemaker_xgboost_container-2.0-py2.py3-none-any.whl /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl
-RUN rm -rf /miniconda3/lib/python3.8/site-packages/numpy-1.21.2.dist-info && \
+RUN rm -rf /miniconda3/lib/python${PYTHON_VERSION}/site-packages/numpy-1.21.2.dist-info && \
     python3 -m pip install --no-cache /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl && \
     python3 -m pip uninstall -y typing && \
     rm /sagemaker_xgboost_container-1.0-py2.py3-none-any.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ MarkupSafe==1.1.1
 Werkzeug==0.15.6
 certifi==2023.7.22
 gevent==23.9.1
-numba==0.59.1
+numba==0.58.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ MarkupSafe==1.1.1
 Werkzeug==0.15.6
 certifi==2023.7.22
 gevent==23.9.1
+numba==0.59.1

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     install_requires=read("requirements.txt"),
     extras_require={"test": read("test-requirements.txt")},
@@ -38,5 +39,5 @@ setup(
             "serve=sagemaker_xgboost_container.serving:serving_entrypoint",
         ]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.9",
 )

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,5 @@ setup(
             "serve=sagemaker_xgboost_container.serving:serving_entrypoint",
         ]
     },
-    python_requires=">=3.9",
+    python_requires=">=3.8",
 )

--- a/src/sagemaker_xgboost_container/dmlc_patch/tracker.py
+++ b/src/sagemaker_xgboost_container/dmlc_patch/tracker.py
@@ -392,11 +392,11 @@ class RabitTracker(object):
         self.thread.start()
 
     def join(self):
-        while self.thread.isAlive():
+        while self.thread.is_alive():
             self.thread.join(1)
 
     def alive(self):
-        return self.thread.isAlive()
+        return self.thread.is_alive()
 
 
 class PSTracker(object):
@@ -437,7 +437,7 @@ class PSTracker(object):
 
     def join(self):
         if self.cmd is not None:
-            while self.thread.isAlive():
+            while self.thread.is_alive():
                 self.thread.join(100)
 
     def slave_envs(self):

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -10,7 +10,7 @@ Pillow==9.1.1
 PyYAML==5.4.1
 boto3==1.17.52
 botocore==1.20.52
-conda==4.10.1
+conda==24.7.1
 cryptography==39.0.1
 gunicorn==19.10.0
 matplotlib==3.4.1

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -3,7 +3,7 @@ import sys
 import pkg_resources
 
 PYTHON_MAJOR_VERSION = 3
-PYTHON_MINOR_VERSION = 8
+PYTHON_MINOR_VERSION = 9
 REQUIREMENTS = """\
 Flask==1.1.1
 Pillow==9.1.1


### PR DESCRIPTION
Python 3.8 is end of life


- Upgrade to python 3.9.
- isAlive was changed to is_alive
- Pin numba to 0.58.1


Tested via unit tests in local docker build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
