### PR TITLE
fix: increase dmlc_timeout floor to 30s for delayed tracker startup

### DIFF
--- a/src/sagemaker_xgboost_container/distributed.py
+++ b/src/sagemaker_xgboost_container/distributed.py
@@ -210,7 +210,7 @@ class Rabit(object):
             if self.max_connect_attempts is not None:
                 self._worker_args["dmlc_retry"] = self.max_connect_attempts
             if self.connect_retry_timeout is not None:
-                self._worker_args["dmlc_timeout"] = self.connect_retry_timeout
+                self._worker_args["dmlc_timeout"] = max(self.connect_retry_timeout, 30)
 
             # Use CommunicatorContext for proper init/finalize
             self._comm_ctx = collective.CommunicatorContext(**self._worker_args)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
