### PR TITLE
fix: accept tree_method=hist for Dask GPU training (XGBoost 3.2.0)

### DIFF
--- a/src/sagemaker_xgboost_container/distributed.py
+++ b/src/sagemaker_xgboost_container/distributed.py
@@ -207,8 +207,6 @@ class Rabit(object):
             # Add task ID for deterministic rank assignment
             self._worker_args["dmlc_task_id"] = str(self.hosts.index(self.current_host))
 
-            if self.max_connect_attempts is not None:
-                self._worker_args["dmlc_retry"] = self.max_connect_attempts
             if self.connect_retry_timeout is not None:
                 self._worker_args["dmlc_timeout"] = max(self.connect_retry_timeout, 30)
 

--- a/src/sagemaker_xgboost_container/distributed_gpu/distributed_gpu_training.py
+++ b/src/sagemaker_xgboost_container/distributed_gpu/distributed_gpu_training.py
@@ -48,7 +48,7 @@ WORKER_STAY_ALIVE_CHECK_FREQ_SEC = 10
 SUPPORTED_TRAINING_CONTENT_TYPES = {CSV, PARQUET}
 
 NON_GPU_ERROR_MSG = (
-    "Dask training is only available for `gpu_hist` training on GPU instances."
+    "Dask training is only available for `hist` (or `gpu_hist`) training on GPU instances."
 )
 PIPE_MODE_ERROR_MSG = (
     "Dask training is not supported for pipe mode input. Please use File mode."
@@ -66,7 +66,7 @@ def validate_gpu_train_configuration(
     data_config: Dict,
 ) -> [str]:
     all_exceptions = []
-    if tree_method_hp != GPU_TREE_METHOD or num_gpus == 0:
+    if tree_method_hp not in (GPU_TREE_METHOD, "hist") or num_gpus == 0:
         all_exceptions.append(NON_GPU_ERROR_MSG)
     if input_mode == PIPE_MODE:
         all_exceptions.append(PIPE_MODE_ERROR_MSG)

--- a/test/unit/distributed_gpu/test_distributed_gpu_training.py
+++ b/test/unit/distributed_gpu/test_distributed_gpu_training.py
@@ -40,6 +40,10 @@ class TestDistributedGPUTraining(unittest.TestCase):
         exc_list = validate_gpu_train_configuration("gpu_hist", 2, 1, "File", "csv", self.train_channel_replicated)
         assert not exc_list
 
+    def test_conditions_pass_hist_tree_method(self):
+        exc_list = validate_gpu_train_configuration("hist", 1, 1, "File", "csv", self.train_channel_replicated)
+        assert not exc_list
+
     def test_conditions_pass_channel_not_replicated_singlehost(self):
         exc_list = validate_gpu_train_configuration("gpu_hist", 1, 1, "File", "csv", self.train_channel_not_replicated)
         assert not exc_list


### PR DESCRIPTION
XGBoost 3.2.0 removed gpu_hist as a valid tree_method. GPU training now uses tree_method=hist with device auto-detection. Update the Dask GPU validation to accept both hist and gpu_hist.

Also remove dmlc_retry from CommunicatorContext args — XGBoost 3.2.0 handles retries internally via dmlc_timeout, and setting dmlc_retry=3 causes premature failure when the tracker takes time to initialize.

*Issue #, if available:*

*Description of changes:*

*Testing:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
