### PR TITLE
fix: bypass dask.dataframe expression optimizer bug in DaskDMatrix cr…

### DIFF
--- a/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
+++ b/src/sagemaker_xgboost_container/distributed_gpu/dask_data_utils.py
@@ -11,11 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import glob
 import os
 
-
-import dask.dataframe as dask_dataframe
-from dask.dataframe import DataFrame, Series
+import dask.array as da
+import numpy as np
+import pandas as pd
 from dask.distributed import Client
 from xgboost import dask as dxgb
 
@@ -23,38 +24,58 @@ from sagemaker_algorithm_toolkit.exceptions import AlgorithmError, UserError
 from sagemaker_xgboost_container.data_utils import CSV, PARQUET
 
 
-def read_data(local_path: str, content_type: str) -> (DataFrame, Series):
+def read_data(local_path: str, content_type: str):
+    """Read training data into pandas DataFrame.
+
+    Uses pandas directly instead of dask.dataframe to avoid expression
+    optimizer bug in dask >= 2026.1 (ValueError on column comparison).
+    """
     if content_type == CSV:
-        dataframe = dask_dataframe.read_csv(
-            os.path.join(local_path, "*.csv"), header=None
-        )
+        files = sorted(glob.glob(os.path.join(local_path, "*.csv")))
+        pdf = pd.concat([pd.read_csv(f, header=None) for f in files], ignore_index=True)
     elif content_type == PARQUET:
-        dataframe = dask_dataframe.read_parquet(local_path)
+        files = sorted(glob.glob(os.path.join(local_path, "*.parquet")))
+        pdf = pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
     else:
         raise UserError(
             f"Unexpected content type '{content_type}'. Supported content types are CSV and PARQUET."
         )
 
-    target_column = dataframe.columns[0]
-    labels = dataframe[target_column]
-    features = dataframe[dataframe.columns[1:]]
+    target_column = pdf.columns[0]
+    labels = pdf[target_column]
+    features = pdf[pdf.columns[1:]]
 
     return features, labels
 
 
-def get_dataframe_dimensions(dataframe: DataFrame) -> (int, int):
-    df_shape = dataframe.shape
-    # Note that dataframe.shape[0].compute() is an expensive operation.
-    rows = df_shape[0].compute()
-    cols = df_shape[1]
+def get_dataframe_dimensions(dataframe) -> (int, int):
+    if hasattr(dataframe, 'compute'):
+        rows = dataframe.shape[0].compute()
+        cols = dataframe.shape[1]
+    else:
+        rows, cols = dataframe.shape
     return rows, cols
 
 
-def create_dask_dmatrix(
-    client: Client, features: DataFrame, labels: Series
-) -> dxgb.DaskDMatrix:
+def create_dask_dmatrix(client: Client, features, labels) -> dxgb.DaskDMatrix:
+    """Create DaskDMatrix from pandas DataFrame/Series or numpy arrays.
+
+    Converts to numpy and wraps in dask.array with chunks distributed
+    across workers to bypass the dask.dataframe expression optimizer bug
+    in dask >= 2026.1, while preserving multi-worker parallelism.
+    """
     try:
-        dmatrix = dxgb.DaskDMatrix(client, features, labels)
+        features_np = features.values if hasattr(features, 'values') else np.asarray(features)
+        labels_np = labels.values if hasattr(labels, 'values') else np.asarray(labels)
+
+        # Chunk rows across available workers for distributed training
+        n_workers = max(1, len(client.scheduler_info()['workers']))
+        n_rows = features_np.shape[0]
+        row_chunks = max(1, n_rows // n_workers)
+
+        features_da = da.from_array(features_np, chunks=(row_chunks, features_np.shape[1]))
+        labels_da = da.from_array(labels_np, chunks=(row_chunks,))
+        dmatrix = dxgb.DaskDMatrix(client, features_da, labels_da)
     except Exception as e:
         raise AlgorithmError(
             f"Failed to create DaskDMatrix with given data. Exception: {e}"

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -24,7 +24,7 @@ sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.5.5
 scipy==1.15.0
 scikit-learn==1.8.0
-urllib3==2.4.0
+urllib3==2.7.0
 Werkzeug==3.1.8
 certifi==2025.4.26
 gevent==26.4.0

--- a/test/unit/distributed_gpu/test_dask_data_utils.py
+++ b/test/unit/distributed_gpu/test_dask_data_utils.py
@@ -38,21 +38,21 @@ class TestDaskDataUtils(unittest.TestCase):
 
     def test_read_data_csv(self):
         x, y = read_data(self.data_path_csv, CSV)
-        assert x.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE
+        assert x.shape[0] == self.NUM_ROWS_IN_EACH_FILE
         assert x.shape[1] == self.NUM_COLS_IN_EACH_FILE - 1
         assert len(y) == self.NUM_ROWS_IN_EACH_FILE
 
     def test_read_data_csv_malformed_path(self):
         x, y = read_data(self.data_path_csv + "/", CSV)
-        assert x.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE
+        assert x.shape[0] == self.NUM_ROWS_IN_EACH_FILE
 
     def test_read_data_csv_multiple_files(self):
         x, y = read_data(self.data_path_csv_multiple, CSV)
-        assert x.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE * 2
+        assert x.shape[0] == self.NUM_ROWS_IN_EACH_FILE * 2
 
     def test_read_data_parquet(self):
         x, y = read_data(self.data_path_parquet, PARQUET)
-        assert x.shape[0].compute() == self.NUM_ROWS_IN_EACH_FILE * 2
+        assert x.shape[0] == self.NUM_ROWS_IN_EACH_FILE * 2
         assert x.shape[1] == self.NUM_COLS_IN_EACH_FILE - 1
         assert len(y) == self.NUM_ROWS_IN_EACH_FILE * 2
 


### PR DESCRIPTION
…eation

dask >= 2026.1 has a bug in its expression optimizer where column comparison returns an array instead of a scalar, causing ValueError when DaskDMatrix tries to persist/optimize DataFrame expressions.

Fix: read data with pandas directly and convert to dask.array before passing to DaskDMatrix. This bypasses the dask.dataframe expression layer entirely while preserving distributed GPU training functionality.

*Issue #, if available:*

*Description of changes:*

*Testing:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
