### PR TITLE
test: expect cryptography 48.0.1 in version assertion

### DIFF
--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -10,7 +10,7 @@ Pillow==12.2.0
 PyYAML==6.0.1
 boto3==1.17.52
 botocore==1.20.52
-cryptography==46.0.7
+cryptography==48.0.1
 gunicorn==23.0.0
 matplotlib==3.9.2
 multi-model-server==1.1.2


### PR DESCRIPTION
## Context

The DLC XGBoost 3.0.5 image bumps `cryptography` from `46.0.7` to `48.0.1` to resolve **GHSA-537c-gmf6-5ccf** — wheels prior to 48.0.1 statically link a vulnerable copy of OpenSSL. (Paired DLC change: aws/deep-learning-containers#6275.)

The version-consistency integration test (`test/resources/versions/train.py`) hardcodes the expected installed package versions and asserts them against the running container. Since the container now ships `cryptography 48.0.1`, the assertion must be updated to match, otherwise the test fails:

```
AssertionError: cryptography requires 46.0.7 but 48.0.1 is installed.
```

## Change

```diff
-cryptography==46.0.7
+cryptography==48.0.1
```

## Merge ordering

This needs to merge to `release-3.0.5` **before** the DLC PR's integration test can pass, because that job clones this branch at runtime to run `train.py`.