### PR TITLE
fix(deps): bump cryptography to 48.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyYAML==6.0.1
 Pillow==12.2.0
 boto3==1.38.0
 botocore==1.38.0
-cryptography==46.0.7
+cryptography==48.0.1
 dask[dataframe]==2026.1.1
 dask-cuda==26.4.0
 cuda-python==12.9.0

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -10,7 +10,7 @@ Pillow==12.2.0
 PyYAML==6.0.1
 boto3==1.38.0
 botocore==1.38.0
-cryptography==46.0.7
+cryptography==48.0.1
 gunicorn==25.3.0
 matplotlib==3.10.9
 multi-model-server==1.1.2


### PR DESCRIPTION
## Description

Bumps `cryptography` from 46.0.7 to 48.0.1 to patch GHSA-537c-gmf6-5ccf: cryptography wheels prior to 48.0.1 statically link a vulnerable copy of OpenSSL.

## Changes
- `requirements.txt`: `cryptography==46.0.7` → `cryptography==48.0.1`
- `test/resources/versions/train.py`: update the version-assertion test to match

## Testing
- Version-assertion test updated to expect 48.0.1.