### PR TITLE
fix(deps): bump cryptography to 48.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyYAML==6.0.1
 Pillow==9.1.1
 boto3==1.17.52
 botocore==1.20.52
-cryptography==45.0.5
+cryptography==48.0.1
 dask[dataframe]==2024.11.2
 dask-cuda==24.12.00
 cuda-python==12.6.0


### PR DESCRIPTION
## Description

Bumps `cryptography` from 45.0.5 to 48.0.1 to patch GHSA-537c-gmf6-5ccf: cryptography wheels prior to 48.0.1 statically link a vulnerable copy of OpenSSL.

This also aligns `requirements.txt` with the version-assertion test in `test/resources/versions/train.py`, which already expects `cryptography==48.0.1`.

## Changes
- `requirements.txt`: `cryptography==45.0.5` → `cryptography==48.0.1`

## Testing
- Version-assertion test already expects 48.0.1; this commit makes the pin consistent.