### PR TITLE
Bump wheel 0.45.1 -> 0.46.2 (CVE-2026-24049)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ sagemaker-inference==1.5.5
 scipy==1.15.0
 scikit-learn==1.5.2
 urllib3==1.26.5
-wheel==0.45.1
+wheel==0.46.2
 jinja2==2.11.3
 MarkupSafe==1.1.1
 Werkzeug==0.15.6

--- a/test/resources/versions/train.py
+++ b/test/resources/versions/train.py
@@ -25,7 +25,7 @@ sagemaker-inference==1.5.5
 scipy==1.15.0
 scikit-learn==1.5.2
 urllib3==1.26.20
-wheel==0.45.1
+wheel==0.46.2
 jinja2==2.11.3
 MarkupSafe==1.1.1
 Werkzeug==0.15.6


### PR DESCRIPTION
## Description

Bump the `wheel` pin from `0.45.1` to `0.46.2` to address CVE-2026-24049 (fixed in wheel 0.46.2). Updates two places that pin the version:

- `requirements.txt` — the installed pin
- `test/resources/versions/train.py` — the version-assertion resource used by the `test_package_version` integration test

Keeping both in sync so the version-assertion test passes with the patched wheel.

## Testing

- `test/integration/local/test_versions.py::test_package_version` asserts installed versions against the resource list; updating both keeps them consistent.

## Motivation

The downstream Deep Learning Containers XGBoost 3.0-5 image bumps `wheel` to 0.46.2 to clear the CVE; its integration tests pull this repo's `release-3.0.5` branch and fail on the stale `wheel==0.45.1` assertion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.